### PR TITLE
Implementation of weights in lttoolbox

### DIFF
--- a/apertium/interchunk.cc
+++ b/apertium/interchunk.cc
@@ -78,7 +78,7 @@ Interchunk::readData(FILE *in)
   any_tag = alphabet(TRXReader::ANY_TAG);
 
   Transducer t;
-  t.read(in, alphabet.size());
+  t.read(in, alphabet.size(), false);
   
   map<int, int> finals;  
   

--- a/apertium/postchunk.cc
+++ b/apertium/postchunk.cc
@@ -79,7 +79,7 @@ Postchunk::readData(FILE *in)
   any_tag = alphabet(TRXReader::ANY_TAG);
 
   Transducer t;
-  t.read(in, alphabet.size());
+  t.read(in, alphabet.size(), false);
   
   map<int, int> finals;  
   

--- a/apertium/tagger_data_hmm.cc
+++ b/apertium/tagger_data_hmm.cc
@@ -237,7 +237,7 @@ TaggerDataHMM::read(FILE *in)
     a[i] = new double[N];
     b[i] = new double[M];
   }
-   
+
   // read a
   for(int i = 0; i != N; i++)
   {
@@ -268,7 +268,7 @@ TaggerDataHMM::read(FILE *in)
 
   // read pattern list
   plist.read(in);
-    
+
   // read discards on ambiguity
   discard.clear();
 

--- a/apertium/tagger_data_lsw.cc
+++ b/apertium/tagger_data_lsw.cc
@@ -35,7 +35,7 @@ TaggerDataLSW::destroy()
   delete [] d;
   }
   d = NULL;
-  
+
   N = 0;
 }
 
@@ -104,9 +104,9 @@ TaggerDataLSW::getD() {
   return d;
 }
 
-int 
+int
 TaggerDataLSW::getN()
-{  
+{
   return N;
 }
 
@@ -122,7 +122,7 @@ TaggerDataLSW::read(FILE *in)
     val += Compression::multibyte_read(in);
     open_class.insert(val);
   }
-  
+
   // forbid_rules
   for(int i = Compression::multibyte_read(in); i != 0; i--)
   {
@@ -132,13 +132,13 @@ TaggerDataLSW::read(FILE *in)
     forbid_rules.push_back(aux);
   }
 
-  
+
   // array_tags
   for(int i = Compression::multibyte_read(in); i != 0; i--)
   {
     array_tags.push_back(Compression::wstring_read(in));
   }
-  
+
   // tag_index
   for(int i = Compression::multibyte_read(in); i != 0; i--)
   {
@@ -197,10 +197,10 @@ TaggerDataLSW::read(FILE *in)
     int k = Compression::multibyte_read(in);
     d[i][j][k] = EndianDoubleUtil::read(in);
   }
-   
+
   // read pattern list
   plist.read(in);
-    
+
   // read discards on ambiguity
   discard.clear();
 
@@ -209,7 +209,7 @@ TaggerDataLSW::read(FILE *in)
   {
     return;
   }
-  
+
   for(unsigned int i = 0; i < limit; i++)
   {
     discard.push_back(Compression::wstring_read(in));
@@ -219,7 +219,7 @@ TaggerDataLSW::read(FILE *in)
 void
 TaggerDataLSW::write(FILE *out)
 {
-  
+
   // open_class
   Compression::multibyte_write(open_class.size(), out);  
   int val = 0;
@@ -229,7 +229,7 @@ TaggerDataLSW::write(FILE *out)
     Compression::multibyte_write(*it-val, out);    
     val = *it;
   }
-  
+
   // forbid_rules
   Compression::multibyte_write(forbid_rules.size(), out);
   for(unsigned int i = 0, limit = forbid_rules.size(); i != limit; i++)
@@ -237,7 +237,7 @@ TaggerDataLSW::write(FILE *out)
     Compression::multibyte_write(forbid_rules[i].tagi, out);
     Compression::multibyte_write(forbid_rules[i].tagj, out);
   }
-  
+
   // array_tags
   Compression::multibyte_write(array_tags.size(), out);
   for(unsigned int i = 0, limit = array_tags.size(); i != limit; i++)
@@ -253,7 +253,7 @@ TaggerDataLSW::write(FILE *out)
     Compression::wstring_write(it->first, out);
     Compression::multibyte_write(it->second, out);
   }
-  
+
   // enforce_rules
   Compression::multibyte_write(enforce_rules.size(), out);
   for(unsigned int i = 0, limit = enforce_rules.size(); i != limit; i++)
@@ -272,7 +272,7 @@ TaggerDataLSW::write(FILE *out)
   {
     Compression::wstring_write(prefer_rules[i], out);
   }
-  
+
   // constants
   constants.write(out);  
 
@@ -306,12 +306,12 @@ TaggerDataLSW::write(FILE *out)
       }
     }
   }
-  
+
   // write pattern list
   plist.write(out);
 
   // write discard list
-  
+
   if(discard.size() != 0)
   {
     Compression::multibyte_write(discard.size(), out);

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -87,7 +87,7 @@ Transfer::readData(FILE *in)
   any_tag = alphabet(TRXReader::ANY_TAG);
 
   Transducer t;
-  t.read(in, alphabet.size());
+  t.read(in, alphabet.size(), false);
 
   map<int, int> finals;
 

--- a/apertium/transfer_data.cc
+++ b/apertium/transfer_data.cc
@@ -128,22 +128,23 @@ TransferData::write(FILE *output)
   alphabet.write(output);
 
   transducer.minimize();
-  set<int> old_finals = transducer.getFinals(); // copy for later removal
+  map<int, double> old_finals = transducer.getFinals(); // copy for later removal
   map<int, int> finals_rules;                   // node id -> rule number
-  map<int, multimap<int, int> >& transitions = transducer.getTransitions();
+  map<int, multimap<int, pair<int, double> > >& transitions = transducer.getTransitions();
   // Find all arcs with "final_symbols" in the transitions, let their source node instead be final,
   // and extract the rule number from the arc. Record relation between source node and rule number
   // in finals_rules. It is now no longer safe to minimize -- but we already did that.
   const wstring rule_sym_pre = L"<RULE_NUMBER:"; // see countToFinalSymbol()
-  for(map<int, multimap<int, int> >::const_iterator it = transitions.begin(),
+  for(map<int, multimap<int, pair<int, double> > >::const_iterator it = transitions.begin(),
         limit = transitions.end(); it != limit; ++it)
   {
     const int src = it->first;
-    for(multimap<int, int>::const_iterator arc = it->second.begin(),
+    for(multimap<int, pair<int, double> >::const_iterator arc = it->second.begin(),
           arclimit = it->second.end(); arc != arclimit; ++arc)
     {
       const int symbol = arc->first;
-      const int trg = arc->second;
+      const int trg = arc->second.first;
+      const double wgt = arc->second.second;
       if(final_symbols.count(symbol) == 0) {
         continue;
       }
@@ -157,18 +158,18 @@ TransferData::write(FILE *output)
         continue;
       }
       const int rule_num = stoi(s.substr(rule_sym_pre.size()));
-      transducer.setFinal(src);
+      transducer.setFinal(src, wgt);
       finals_rules[src] = rule_num;
     }
   }
   // Remove the old finals:
-  for(set<int>::const_iterator it = old_finals.begin(), limit = old_finals.end();
+  for(map<int, double>::const_iterator it = old_finals.begin(), limit = old_finals.end();
       it != limit; ++it)
   {
-    transducer.setFinal(*it, false);
+    transducer.setFinal(it->first, it->second, false);
   }
 
-  transducer.write(output, alphabet.size());
+  transducer.write(output, alphabet.size(), false);
 
   // finals_rules
 

--- a/apertium/transfer_mult.cc
+++ b/apertium/transfer_mult.cc
@@ -80,7 +80,7 @@ TransferMult::readData(FILE *in)
   any_tag = alphabet(TRXReader::ANY_TAG);
 
   Transducer t;
-  t.read(in, alphabet.size());
+  t.read(in, alphabet.size(), false);
 
   map<int, int> finals;
 

--- a/apertium/trx_reader.h
+++ b/apertium/trx_reader.h
@@ -36,6 +36,7 @@ private:
     wstring tags;
   };
 
+  double default_weight;
   multimap<wstring, LemmaTags, Ltstr> cat_items;
   TransferData td;
 


### PR DESCRIPTION
Make all the tweaks necessary to have a minimal implementation
of weights in att_compiler.
Using the same option names as `hfst-proc` we add options in
lt-proc to output n-best paths using the weight values.

Closes https://github.com/apertium/lttoolbox/issues/2
Closes https://github.com/apertium/lttoolbox/issues/3
Fixes https://github.com/apertium/lttoolbox/issues/12