### PR TITLE
Consolidating map assignment across C++ versions

### DIFF
--- a/apertium/collection.cc
+++ b/apertium/collection.cc
@@ -45,7 +45,9 @@ Collection::operator[](const set<int> &t)
 {
   if(has_not(t))
   {
-    index[t] = index.size()-1;
+    int position = index.size();
+    index[t] = position;
+
     element.push_back(&(index.find(t)->first));
   }
   return index[t];


### PR DESCRIPTION
There was a bug in the tagger, that ended up being in `Collection.cc`. It seemed really weird at the very beginning, but it turns out it's documented in several places, including the standard ([Refining Expression Evaluation Order for Idiomatic C++, proposal, 2014 [1]](http://open-std.org/JTC1/SC22/WG21/docs/papers/2014/n4228.pdf), [Unspecified behaviour in C++ when adding to map [2]](https://blog.jayway.com/2015/09/08/undefined-behaviour-in-c-when-adding-to-map/))

The problem is with this piece of code

    #include 
        int main() { 
        std::map m; 
        m[0] = m.size();
    }

It seems that in gcc 6.x.x, m[1] got the value of 1. The reason for that is the left size of the assignment is evaluated first to obtain a reference, and as [] creates a new element if it doesn't exist. So when m.size() is evaluated, the size is actually 1.

Clang, on the other hand, was evaluating first m.size(), getting 0, and then assigning that as the value of m[0].

With gcc 7 ([Compiler support for C++2017 [3]](https://www.bfilipek.com/2017/12/cpp-status-2017.html#compiler-support-for-c17), finally a change part of C++2017 called ["Refining Expression Evaluation Order for Idiomatic C++" [4]](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0145r3.pdf) got supported. And it seems that this brings the clang behavior to the old C++, which basically breaks apertium-tagger [here [5]]:(https://github.com/apertium/apertium/blob/master/apertium/collection.cc#L48)

    index[t] = index.size()-1;

In _old_ systems (with GCC 6x), this gets evaluated as

    index[t] = 0

but on new systems (with GCC 7x), this becomes

    index[t] = -1

I've added a proposal for a fix, by keeping the way Collection.cc was implemented but without relying on any specific version of C++. 

    int position = index.size();
    index[t] = position;

We could also fix it doing things like

    #if __GNUC__ >= 7
    index[t] = index.size();
    #else
    index[t] = index.size()-1;
    #endif

or with the __cplusplus macro instead. But I personally think the proposed fix is better. 

-----
References

[1] http://open-std.org/JTC1/SC22/WG21/docs/papers/2014/n4228.pdf
[2] https://blog.jayway.com/2015/09/08/undefined-behaviour-in-c-when-adding-to-map/
[3] https://www.bfilipek.com/2017/12/cpp-status-2017.html#compiler-support-for-c17
[4] http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0145r3.pdf
[5] https://github.com/apertium/apertium/blob/master/apertium/collection.cc#L48