### PR TITLE
Adding ability to detect reference in transfer

### DIFF
--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -313,6 +313,8 @@ Transfer::evalString(xmlNode *element)
         }
         break;
 
+      //case ti_clip_cr [[anaphora]]
+
       case ti_linkto_sl:
         if(checkIndex(element, ti.getPos(), lword))
         {
@@ -340,6 +342,8 @@ Transfer::evalString(xmlNode *element)
           }
         }
         break;
+
+      //case ti_linkto_cr [[anaphora]]
 
       case ti_var:
         return variables[ti.getContent()];
@@ -379,6 +383,8 @@ Transfer::evalString(xmlNode *element)
           return caseOf(word[ti.getPos()]->target(attr_items[ti.getContent()]));
         }
         break;
+
+      //case ti_case_of_cr [[anaphora]]
 
       default:
         return "";
@@ -425,16 +431,17 @@ Transfer::evalString(xmlNode *element)
       {
         evalStringCache[element] = TransferInstr(ti_linkto_sl, (const char *) part, pos, (void *) as, queue);
       }
-      else
+      else //else if(!xmlStrcmp(side, (const xmlChar *) "tl")) [[anaphora]]
       {
         evalStringCache[element] = TransferInstr(ti_linkto_tl, (const char *) part, pos, (void *) as, queue);
       }
+      //else for cr [[anaphora]]
     }
     else if(!xmlStrcmp(side, (const xmlChar *) "sl"))
     {
       evalStringCache[element] = TransferInstr(ti_clip_sl, (const char *) part, pos, NULL, queue);
     }
-    else
+    else //if and else for cr [[anaphora]]
     {
       evalStringCache[element] = TransferInstr(ti_clip_tl, (const char *) part, pos, NULL, queue);
     }
@@ -504,7 +511,7 @@ Transfer::evalString(xmlNode *element)
     {
       evalStringCache[element] = TransferInstr(ti_case_of_sl, (const char *) part, pos);
     }
-    else
+    else //if [[anaphora]]
     {
       evalStringCache[element] = TransferInstr(ti_case_of_tl, (const char *) part, pos);
     }
@@ -939,6 +946,8 @@ Transfer::processLet(xmlNode *localroot)
         }
         return;
 
+      //case ti_clip_cr [[anaphora]]
+
       default:
         return;
     }
@@ -996,7 +1005,7 @@ Transfer::processLet(xmlNode *localroot)
       word[pos]->setTarget(attr_items[(const char *) part], evalString(rightSide), queue);
       evalStringCache[leftSide] = TransferInstr(ti_clip_tl, (const char *) part, pos, NULL, queue);
     }
-    else
+    else //if and add for cr [[anaphora]]
     {
       word[pos]->setSource(attr_items[(const char *) part], evalString(rightSide), queue);
       evalStringCache[leftSide] = TransferInstr(ti_clip_sl, (const char *) part, pos, NULL, queue);
@@ -1086,7 +1095,7 @@ Transfer::processModifyCase(xmlNode *localroot)
 				      word[pos]->source(attr_items[(const char *) part], queue));
       word[pos]->setSource(attr_items[(const char *) part], result);
     }
-    else
+    else //if and add for cr [[anaphora]]
     {
       string const result = copycase(evalString(rightSide),
 				     word[pos]->target(attr_items[(const char *) part], queue));
@@ -2032,7 +2041,7 @@ Transfer::transfer(FILE *in, FILE *out)
 	      tr = fstp.biltransWithQueue(*tmpword[0], false);
             }
           }
-          else if(preBilingual)
+          else if(preBilingual) //add for cr? [[anaphora]]
           {
             wstring sl;
             wstring tl;
@@ -2220,7 +2229,7 @@ Transfer::applyRule()
                                  UtfConverter::toUtf8(tr.first),
                                  tr.second);
     }
-    else if(preBilingual)
+    else if(preBilingual) //add for cr? [[anaphora]]
     {
       wstring sl;
       wstring tl;

--- a/apertium/transfer_word.cc
+++ b/apertium/transfer_word.cc
@@ -25,6 +25,7 @@ TransferWord::copy(TransferWord const &o)
 {
   s_str = o.s_str;
   t_str = o.t_str;
+  r_str = o.r_str;
   queue_length = o.queue_length;
 }
 
@@ -38,9 +39,9 @@ queue_length(0)
 {
 }
 
-TransferWord::TransferWord(string const &src, string const &tgt, int queue)
+TransferWord::TransferWord(string const &src, string const &tgt, string const &ref, int queue)
 {
-  init(src, tgt);
+  init(src, tgt, ref);
   queue_length = queue;
 }
 
@@ -66,10 +67,11 @@ TransferWord::operator =(TransferWord const &o)
 }
 
 void
-TransferWord::init(string const &src, string const &tgt)
+TransferWord::init(string const &src, string const &tgt, string const &ref)
 {
   s_str = src;
   t_str = tgt;
+  r_str = ref;
 }
 
 string
@@ -95,6 +97,19 @@ TransferWord::target(ApertiumRE const &part, bool with_queue)
   else
   {
     return part.match(t_str.substr(0, t_str.size() - queue_length));
+  }
+}
+
+string
+TransferWord::reference(ApertiumRE const &part, bool with_queue)
+{
+  if(with_queue)
+  {
+    return part.match(r_str);
+  }
+  else
+  {
+    return part.match(r_str.substr(0, r_str.size() - queue_length));
   }
 }
 
@@ -127,5 +142,21 @@ TransferWord::setTarget(ApertiumRE const &part, string const &value,
     string mystring = t_str.substr(0, t_str.size() - queue_length);
     part.replace(mystring, value);
     t_str = mystring + t_str.substr(t_str.size() - queue_length);
+  }
+}
+
+void
+TransferWord::setReference(ApertiumRE const &part, string const &value,
+      bool with_queue)
+{
+  if(with_queue)
+  {
+    part.replace(r_str, value);
+  }
+  else
+  {
+    string mystring = r_str.substr(0, r_str.size() - queue_length);
+    part.replace(mystring, value);
+    r_str = mystring + r_str.substr(r_str.size() - queue_length);
   }
 }

--- a/apertium/transfer_word.h
+++ b/apertium/transfer_word.h
@@ -42,6 +42,11 @@ private:
   string t_str;
 
   /**
+   * Reference word
+   */
+  string r_str;
+
+  /**
    * Queue length
    */
   int queue_length;
@@ -58,17 +63,17 @@ private:
   void destroy();
 
   /**
-   * Accesses the source/target side of a word using the specified part
-   * @param str tipically s_str or t_str
+   * Accesses the source/target/reference side of a word using the specified part
+   * @param str typically s_str or t_str or r_str
    * @param part regular expression to match/access
    * @return reference to matched/accessed string
    */
   string access(string const &str, ApertiumRE const &part);
 
   /**
-   * Assings a value to the source/target side of a word using the
+   * Assings a value to the source/target/reference side of a word using the
    * specified part
-   * @param str tipically s_str or t_str
+   * @param str typically s_str or t_str or r_str
    * @param part regular expression to match/access
    * @param value the string to be assigned
    */
@@ -94,9 +99,10 @@ public:
    * Parametric constructor calling init()
    * @param src source word
    * @param tgt target word
+   * @param ref reference word
    * @param queue queue lenght
    */
-  TransferWord(string const &src, string const &tgt, int queue = 0);
+  TransferWord(string const &src, string const &tgt, string const &ref, int queue = 0);
 
   /**
    * Assignment operator
@@ -106,12 +112,13 @@ public:
   TransferWord & operator =(TransferWord const &o);
 
   /**
-   * Sets a bi-word (a source language word and its counterpart in target
-   * language
+   * Sets a tri-word (a source language word, its counterpart in target
+   * language, and a reference if one exists
    * @param src source word
    * @param tgt target word
+   * @param ref reference word
    */
-  void init(string const &src, string const &tgt);
+  void init(string const &src, string const &tgt, string const &ref);
 
   /**
    * Reference a source language word part
@@ -130,6 +137,14 @@ public:
   string target(ApertiumRE const &part, bool with_queue = true);
 
   /**
+   * Reference the reference word part
+   * @param part regular expression to match
+   * @param with_queue access taking into account the queue
+   * @returns reference to the part of string matched
+   */
+  string reference(ApertiumRE const &part, bool with_queue = true);
+
+  /**
    * Sets a value for a source language word part
    * @param part regular expression to match
    * @param value the new value for the given part
@@ -146,6 +161,15 @@ public:
    */
   void setTarget(ApertiumRE const &part, string const &value,
 		 bool with_queue = true);
+
+  /**
+   * Sets a value for a reference word part
+   * @param part regular expression to match
+   * @param value the new value for the given part
+   * @param with_queue access taking or not into account the queue
+   */
+  void setReference(ApertiumRE const &part, string const &value,
+     bool with_queue = true);
 };
 
 #endif


### PR DESCRIPTION
Modified transfer_word.cc and its header file to define reference so that it can be detected when we write transfer rules for anaphora resolution.

Also added comments in transfer.cc to mark where code needs to be modified.
Further changes will be made directly in the branch.