### PR TITLE
swig wrapper: load dictionary during instantiation

### DIFF
--- a/python/apertium_core.i
+++ b/python/apertium_core.i
@@ -58,11 +58,11 @@ void pretransfer(char arg, char *input_path, char *output_path)
   fclose(output);
 }
 
-class transfer: public Transfer
+class ApertiumTransfer: public Transfer
 {
   public:
 
-  transfer(char *transferfile, char *datafile)
+  ApertiumTransfer(char *transferfile, char *datafile)
   {
     read(transferfile, datafile);
   }
@@ -81,27 +81,27 @@ class transfer: public Transfer
           setUseBilingual(false);
           break;
     }
-    Transfer::transfer(input, output);
+    transfer(input, output);
     fclose(input);
     fclose(output);
   }
 };
 
-class tagger: public Apertium::apertium_tagger
+class ApertiumTagger: public Apertium::apertium_tagger
 {
   public:
   /**
    * Imitates functionality of apertium-tagger
    * tagger::tagger() passes int and char** to apertium_tagger::apertium_tagger() int&, char**& respectively
    */
-  tagger(int argc, char **argv): apertium_tagger(argc, argv){}
+  ApertiumTagger(int argc, char **argv): apertium_tagger(argc, argv){}
 };
 
-class interchunk: public Interchunk
+class ApertiumInterchunk: public Interchunk
 {
   public:
 
-  interchunk(char *transferfile, char *datafile)
+  ApertiumInterchunk(char *transferfile, char *datafile)
   {
     read(transferfile, datafile);
   }
@@ -109,17 +109,17 @@ class interchunk: public Interchunk
   void interchunk_text(char arg, char *input_path, char *output_path)
   {
     FILE *input = fopen(input_path, "r"), *output = fopen(output_path, "w");
-    Interchunk::interchunk(input, output);
+    interchunk(input, output);
     fclose(input);
     fclose(output);
   }
 };
 
-class postchunk: public Postchunk
+class ApertiumPostchunk: public Postchunk
 {
   public:
 
-  postchunk(char *transferfile, char *datafile)
+  ApertiumPostchunk(char *transferfile, char *datafile)
   {
     read(transferfile, datafile);
   }
@@ -127,7 +127,7 @@ class postchunk: public Postchunk
  void postchunk_text(char arg, char *input_path, char *output_path)
   {
     FILE *input = fopen(input_path, "r"), *output = fopen(output_path, "w");
-    Postchunk::postchunk(input, output);
+    postchunk(input, output);
     fclose(input);
     fclose(output);
   }

--- a/python/apertium_core.i
+++ b/python/apertium_core.i
@@ -1,16 +1,51 @@
 %module apertium_core
 
-%{
+%include <apertium/interchunk.h>
+%include <apertium/pretransfer.h>
+%include <apertium/postchunk.h>
+%include <apertium/tagger.h>
+%include <apertium/transfer.h>
+
+// Wrapper on char ** for char **argv
+// Modified for python 3 from http://www.swig.org/Doc1.3/Python.html#Python_nn59
+
+%typemap(in) char ** {
+  if (PyList_Check($input)) {
+    int size = PyList_Size($input);
+    int i = 0;
+    $1 = (char **) malloc((size+1)*sizeof(char *));
+    for (i = 0; i < size; i++) {
+      PyObject *py_obj = PyList_GetItem($input, i);
+      if (PyUnicode_Check(py_obj)) {
+        $1[i] = strdup(PyUnicode_AsUTF8(py_obj));
+      }
+      else {
+        PyErr_SetString(PyExc_TypeError, "list must contain strings");
+        free($1);
+        return NULL;
+      }
+    }
+    $1[i] = 0;
+  } else {
+    PyErr_SetString(PyExc_TypeError, "not a list");
+    return NULL;
+  }
+}
+
+%typemap(freearg) char ** {
+  free((char *) $1);
+}
+
+%inline%{
 #define SWIG_FILE_WITH_INIT
 #include <apertium/interchunk.h>
 #include <apertium/pretransfer.h>
 #include <apertium/postchunk.h>
 #include <apertium/tagger.h>
 #include <apertium/transfer.h>
-
 class apertium: public Transfer, public Interchunk, public Postchunk
 {
-public:
+  public:
   /**
    * Imitates functionality of apertium-core binaries using file path
    */
@@ -22,7 +57,7 @@ public:
 
 class tagger: public Apertium::apertium_tagger
 {
-public:
+  public:
   /**
    * Imitates functionality of apertium-tagger
    * tagger::tagger() passes int and char** to apertium_tagger::apertium_tagger() int&, char**& respectively
@@ -83,54 +118,3 @@ apertium::postchunk_text(char arg, char *transferfile, char *datafile, char *inp
 }
 
 %}
-
-%include <apertium/interchunk.h>
-%include <apertium/pretransfer.h>
-%include <apertium/postchunk.h>
-%include <apertium/tagger.h>
-%include <apertium/transfer.h>
-
-// Wrapper on char ** for char **argv
-// Modified for python 3 from http://www.swig.org/Doc1.3/Python.html#Python_nn59
-
-%typemap(in) char ** {
-  if (PyList_Check($input)) {
-    int size = PyList_Size($input);
-    int i = 0;
-    $1 = (char **) malloc((size+1)*sizeof(char *));
-    for (i = 0; i < size; i++) {
-      PyObject *py_obj = PyList_GetItem($input, i);
-      if (PyUnicode_Check(py_obj)) {
-        $1[i] = strdup(PyUnicode_AsUTF8(py_obj));
-      }
-      else {
-        PyErr_SetString(PyExc_TypeError, "list must contain strings");
-        free($1);
-        return NULL;
-      }
-    }
-    $1[i] = 0;
-  } else {
-    PyErr_SetString(PyExc_TypeError, "not a list");
-    return NULL;
-  }
-}
-
-%typemap(freearg) char ** {
-  free((char *) $1);
-}
-
-class apertium: public Transfer, public Interchunk, public Postchunk
-{
-public:
-  void interchunk_text(char arg, char *transferfile, char *datafile, char *input_path, char *output_path);
-  void pretransfer(char arg, char *input_path, char *output_path);
-  void postchunk_text(char arg, char *transferfile, char *datafile, char *input_path, char *output_path);
-  void transfer_text(char arg, char *transferfile, char *datafile, char *input_path, char *output_path);
-};
-
-class tagger: public Apertium::apertium_tagger
-{
-public:
-  tagger(int argc, char **argv): apertium_tagger(argc, argv);
-};

--- a/python/apertium_core.i
+++ b/python/apertium_core.i
@@ -43,16 +43,48 @@
 #include <apertium/postchunk.h>
 #include <apertium/tagger.h>
 #include <apertium/transfer.h>
-class apertium: public Transfer, public Interchunk, public Postchunk
+
+/**
+ * Imitates functionality of apertium-core binaries using file path
+ */
+
+
+void pretransfer(char arg, char *input_path, char *output_path)
+{
+  bool useMaxEnt = false;
+  FILE *input = fopen(input_path, "r"), *output = fopen(output_path, "w");
+  processStream(input, output, false, false, false);
+  fclose(input);
+  fclose(output);
+}
+
+class transfer: public Transfer
 {
   public:
-  /**
-   * Imitates functionality of apertium-core binaries using file path
-   */
-  void interchunk_text(char arg, char *transferfile, char *datafile, char *input_path, char *output_path);
-  void pretransfer(char arg, char *input_path, char *output_path);
-  void postchunk_text(char arg, char *transferfile, char *datafile, char *input_path, char *output_path);
-  void transfer_text(char arg, char *transferfile, char *datafile, char *input_path, char *output_path);
+
+  transfer(char *transferfile, char *datafile)
+  {
+    read(transferfile, datafile);
+  }
+
+  void transfer_text(char arg, char *input_path, char *output_path)
+  {
+    FILE *input = fopen(input_path, "r"), *output = fopen(output_path, "w");
+    switch(arg)
+    {
+        case 'b':
+          setPreBilingual(true);
+          setUseBilingual(false);
+          break;
+
+        case 'n':
+          setUseBilingual(false);
+          break;
+    }
+    Transfer::transfer(input, output);
+    fclose(input);
+    fclose(output);
+  }
 };
 
 class tagger: public Apertium::apertium_tagger
@@ -65,56 +97,40 @@ class tagger: public Apertium::apertium_tagger
   tagger(int argc, char **argv): apertium_tagger(argc, argv){}
 };
 
-void
-apertium::transfer_text(char arg, char *transferfile, char *datafile, char *input_path, char *output_path)
+class interchunk: public Interchunk
 {
-  FILE *input = fopen(input_path, "r"), *output = fopen(output_path, "w");
+  public:
 
-  switch(arg)
+  interchunk(char *transferfile, char *datafile)
   {
-      case 'b':
-        setPreBilingual(true);
-        setUseBilingual(false);
-        break;
-
-      case 'n':
-        setUseBilingual(false);
-        break;
+    read(transferfile, datafile);
   }
-  Transfer::read(transferfile, datafile);
-  transfer(input, output);
-  fclose(input);
-  fclose(output);
-}
 
-void
-apertium::interchunk_text(char arg, char *transferfile, char *datafile, char *input_path, char *output_path)
-{
-  FILE *input = fopen(input_path, "r"), *output = fopen(output_path, "w");
-  Interchunk::read(transferfile, datafile);
-  interchunk(input, output);
-  fclose(input);
-  fclose(output);
-}
+  void interchunk_text(char arg, char *input_path, char *output_path)
+  {
+    FILE *input = fopen(input_path, "r"), *output = fopen(output_path, "w");
+    Interchunk::interchunk(input, output);
+    fclose(input);
+    fclose(output);
+  }
+};
 
-void
-apertium::pretransfer(char arg, char *input_path, char *output_path)
+class postchunk: public Postchunk
 {
-  bool useMaxEnt = false;
-  FILE *input = fopen(input_path, "r"), *output = fopen(output_path, "w");
-  processStream(input, output, false, false, false);
-  fclose(input);
-  fclose(output);
-}
+  public:
 
-void
-apertium::postchunk_text(char arg, char *transferfile, char *datafile, char *input_path, char *output_path)
-{
-  FILE *input = fopen(input_path, "r"), *output = fopen(output_path, "w");
-  Postchunk::read(transferfile, datafile);
-  postchunk(input, output);
-  fclose(input);
-  fclose(output);
-}
+  postchunk(char *transferfile, char *datafile)
+  {
+    read(transferfile, datafile);
+  }
+
+ void postchunk_text(char arg, char *input_path, char *output_path)
+  {
+    FILE *input = fopen(input_path, "r"), *output = fopen(output_path, "w");
+    Postchunk::postchunk(input, output);
+    fclose(input);
+    fclose(output);
+  }
+};
 
 %}


### PR DESCRIPTION
- use `%inline %{ %}` to reduce code duplication
- Separate class for each binary, except for `pretransfer`
- No changes in `apertium-tagger`