### PR TITLE
Changes for Anaphora Resolution

### DIFF
--- a/apertium/interchunk.cc
+++ b/apertium/interchunk.cc
@@ -1417,7 +1417,7 @@ Interchunk::interchunk(FILE *in, FILE *out)
     interchunk_wrapper_null_flush(in, out);
   }
 
-  int last = 0;
+  unsigned int last = input_buffer.getPos();
 
   output = out;
   ms.init(me->getInitial());

--- a/apertium/postchunk.cc
+++ b/apertium/postchunk.cc
@@ -1580,7 +1580,7 @@ Postchunk::postchunk(FILE *in, FILE *out)
     postchunk_wrapper_null_flush(in, out);
   }
 
-  int last = 0;
+  unsigned int last = input_buffer.getPos();
 
   output = out;
   ms.init(me->getInitial());

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -543,7 +543,11 @@ Transfer::evalString(xmlNode *element)
     {
       evalStringCache[element] = TransferInstr(ti_case_of_sl, (const char *) part, pos);
     }
-    else //if [[anaphora]]
+    else if(!xmlStrcmp(side, (const xmlChar *) "ref")) //[[anaphora]]
+    {
+      evalStringCache[element] = TransferInstr(ti_case_of_ref, (const char *) part, pos);
+    }
+    else
     {
       evalStringCache[element] = TransferInstr(ti_case_of_tl, (const char *) part, pos);
     }

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -1915,8 +1915,8 @@ Transfer::transfer(FILE *in, FILE *out)
     transfer_wrapper_null_flush(in, out);
   }
 
-  unsigned int last = 0;
-  unsigned int prev_last = 0;
+  unsigned int last = input_buffer.getPos();
+  unsigned int prev_last = last;
   int lastrule_id = -1;
   set<int> banned_rules;
 

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -1745,7 +1745,7 @@ Transfer::processContainsSubstring(xmlNode *localroot)
 }
 
 string
-Transfer::copycase(string const &source_word, string const &target_word) //[[anaphora]] NOT SURE ?
+Transfer::copycase(string const &source_word, string const &target_word)
 {
   wstring result;
   wstring const s_word = UtfConverter::fromUtf8(source_word);
@@ -2093,7 +2093,7 @@ Transfer::transfer(FILE *in, FILE *out)
 	      tr = fstp.biltransWithQueue(*tmpword[0], false);
             }
           }
-          else if(preBilingual) //add for cr? seems to be for seenSlash ==2 [[anaphora]]
+          else if(preBilingual) // [[anaphora]]
           {
             wstring sl;
             wstring tl;
@@ -2127,6 +2127,8 @@ Transfer::transfer(FILE *in, FILE *out)
               else if(*it == L'/')
               {
                 seenSlash++;
+
+                ref.clear(); //[[anaphora]] //the word after the last slash is the ref
                 continue;
               }
               if(seenSlash == 0)
@@ -2137,13 +2139,9 @@ Transfer::transfer(FILE *in, FILE *out)
               {
                 tl.push_back(*it);
               }
-              else if(seenSlash == 2) //[[anaphora]]
+              else //[[anaphora]]
               {
                 ref.push_back(*it);
-              }
-              else if(seenSlash > 2)
-              {
-                break;
               }
             }
             //tmpword[0]->assign(sl);
@@ -2295,7 +2293,7 @@ Transfer::applyRule()
                                  UtfConverter::toUtf8(refx), //[[anaphora]]
                                  tr.second);
     }
-    else if(preBilingual) //add for cr? [[anaphora]]
+    else if(preBilingual)[[anaphora]]
     {
       wstring sl;
       wstring tl;
@@ -2330,6 +2328,8 @@ Transfer::applyRule()
         if(*it == L'/')
         {
           seenSlash++;
+
+          ref.clear(); //[[anaphora]] word after last slash is ref
           continue;
         }
         if(seenSlash == 0)
@@ -2340,13 +2340,9 @@ Transfer::applyRule()
         {
           tl.push_back(*it);
         }
-        else if(seenSlash == 2) //[[anaphora]]
+        else //[[anaphora]]
         {
           ref.push_back(*it);
-        }
-        else if(seenSlash > 2)
-        {
-          break;
         }
       }
       tr = pair<wstring, int>(tl, false);

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -313,7 +313,6 @@ Transfer::evalString(xmlNode *element)
         }
         break;
 
-      //case ti_clip_cr [[anaphora]]
       case ti_clip_ref:
         if(checkIndex(element, ti.getPos(), lword))
         {
@@ -349,7 +348,6 @@ Transfer::evalString(xmlNode *element)
         }
         break;
 
-      //case ti_linkto_cr [[anaphora]]
       case ti_linkto_ref:
         if(checkIndex(element, ti.getPos(), lword))
         {
@@ -403,7 +401,6 @@ Transfer::evalString(xmlNode *element)
         }
         break;
 
-      //case ti_case_of_cr [[anaphora]]
       case ti_case_of_ref:
         if(checkIndex(element, ti.getPos(), lword))
         {
@@ -456,7 +453,7 @@ Transfer::evalString(xmlNode *element)
       {
         evalStringCache[element] = TransferInstr(ti_linkto_sl, (const char *) part, pos, (void *) as, queue);
       }
-      else if(!xmlStrcmp(side, (const xmlChar *) "ref")) //[[anaphora]]
+      else if(!xmlStrcmp(side, (const xmlChar *) "ref"))
       {
         evalStringCache[element] = TransferInstr(ti_linkto_ref, (const char *) part, pos, (void *) as, queue);
       }
@@ -469,7 +466,7 @@ Transfer::evalString(xmlNode *element)
     {
       evalStringCache[element] = TransferInstr(ti_clip_sl, (const char *) part, pos, NULL, queue);
     }
-    else if(!xmlStrcmp(side, (const xmlChar *) "ref")) //[[anaphora]]
+    else if(!xmlStrcmp(side, (const xmlChar *) "ref"))
     {
       evalStringCache[element] = TransferInstr(ti_clip_ref, (const char *) part, pos, NULL, queue);
     }
@@ -543,7 +540,7 @@ Transfer::evalString(xmlNode *element)
     {
       evalStringCache[element] = TransferInstr(ti_case_of_sl, (const char *) part, pos);
     }
-    else if(!xmlStrcmp(side, (const xmlChar *) "ref")) //[[anaphora]]
+    else if(!xmlStrcmp(side, (const xmlChar *) "ref"))
     {
       evalStringCache[element] = TransferInstr(ti_case_of_ref, (const char *) part, pos);
     }
@@ -982,7 +979,6 @@ Transfer::processLet(xmlNode *localroot)
         }
         return;
 
-      //[[anaphora]]
       case ti_clip_ref:
         if (checkIndex(leftSide, ti.getPos(), lword)) {
           word[ti.getPos()]->setReference(attr_items[ti.getContent()], evalString(rightSide), ti.getCondition());
@@ -1046,7 +1042,7 @@ Transfer::processLet(xmlNode *localroot)
       word[pos]->setTarget(attr_items[(const char *) part], evalString(rightSide), queue);
       evalStringCache[leftSide] = TransferInstr(ti_clip_tl, (const char *) part, pos, NULL, queue);
     }
-    else if(!xmlStrcmp(side, (const xmlChar *) "ref")) //[[anaphora]]
+    else if(!xmlStrcmp(side, (const xmlChar *) "ref"))
     {
       word[pos]->setReference(attr_items[(const char *) part], evalString(rightSide), queue);
       evalStringCache[leftSide] = TransferInstr(ti_clip_ref, (const char *) part, pos, NULL, queue);
@@ -1141,7 +1137,7 @@ Transfer::processModifyCase(xmlNode *localroot)
 				      word[pos]->source(attr_items[(const char *) part], queue));
       word[pos]->setSource(attr_items[(const char *) part], result);
     }
-    else if(!xmlStrcmp(side, (const xmlChar *) "ref")) //[[anaphora]]
+    else if(!xmlStrcmp(side, (const xmlChar *) "ref"))
     {
       string const result = copycase(evalString(rightSide),
               word[pos]->reference(attr_items[(const char *) part], queue));
@@ -2093,11 +2089,11 @@ Transfer::transfer(FILE *in, FILE *out)
 	      tr = fstp.biltransWithQueue(*tmpword[0], false);
             }
           }
-          else if(preBilingual) // [[anaphora]]
+          else if(preBilingual)
           {
             wstring sl;
             wstring tl;
-            wstring ref; //[[anaphora]]
+            wstring ref;
 
             int seenSlash = 0;
             for(wstring::const_iterator it = tmpword[0]->begin(); it != tmpword[0]->end(); it++)
@@ -2116,7 +2112,7 @@ Transfer::transfer(FILE *in, FILE *out)
                   it++;
                   tl.push_back(*it);
                 }
-                else //[[anaphora]]
+                else
                 {
                   ref.push_back(*it);
                   it++;
@@ -2128,7 +2124,7 @@ Transfer::transfer(FILE *in, FILE *out)
               {
                 seenSlash++;
 
-                ref.clear(); //[[anaphora]] //the word after the last slash is the ref
+                ref.clear(); //the word after the last slash is the ref
                 continue;
               }
               if(seenSlash == 0)
@@ -2139,13 +2135,13 @@ Transfer::transfer(FILE *in, FILE *out)
               {
                 tl.push_back(*it);
               }
-              else //[[anaphora]]
+              else
               {
                 ref.push_back(*it);
               }
             }
             //tmpword[0]->assign(sl);
-            tr = pair<wstring, int>(tl, false); // [[anaphora]] what is tr?
+            tr = pair<wstring, int>(tl, false);
             //wcerr << L"pb: " << *tmpword[0] << L" :: " << sl << L" >> " << tl << endl ;
           }
           else
@@ -2290,14 +2286,14 @@ Transfer::applyRule()
       wstring refx;
       word[i] = new TransferWord(UtfConverter::toUtf8(*tmpword[i]),
                                  UtfConverter::toUtf8(tr.first),
-                                 UtfConverter::toUtf8(refx), //[[anaphora]]
+                                 UtfConverter::toUtf8(refx),
                                  tr.second);
     }
-    else if(preBilingual)[[anaphora]]
+    else if(preBilingual)
     {
       wstring sl;
       wstring tl;
-      wstring ref; //[[anaphora]]
+      wstring ref;
 
       int seenSlash = 0;
       for(wstring::const_iterator it = tmpword[i]->begin(); it != tmpword[i]->end(); it++)
@@ -2329,7 +2325,7 @@ Transfer::applyRule()
         {
           seenSlash++;
 
-          ref.clear(); //[[anaphora]] word after last slash is ref
+          ref.clear(); //word after last slash is ref
           continue;
         }
         if(seenSlash == 0)
@@ -2340,7 +2336,7 @@ Transfer::applyRule()
         {
           tl.push_back(*it);
         }
-        else //[[anaphora]]
+        else
         {
           ref.push_back(*it);
         }
@@ -2348,16 +2344,16 @@ Transfer::applyRule()
       tr = pair<wstring, int>(tl, false);
       word[i] = new TransferWord(UtfConverter::toUtf8(sl),
                                  UtfConverter::toUtf8(tr.first),
-                                 UtfConverter::toUtf8(ref), //[[anaphora]]
+                                 UtfConverter::toUtf8(ref),
                                  tr.second);
     }
-    else // neither useBilingual nor preBilingual (sl==tl) [[anaphora]] add for ref?
+    else // neither useBilingual nor preBilingual (sl==tl)
     {
       tr = pair<wstring, int>(*tmpword[i], false);
       wstring refx;
       word[i] = new TransferWord(UtfConverter::toUtf8(*tmpword[i]),
                                  UtfConverter::toUtf8(tr.first),
-                                 UtfConverter::toUtf8(refx), //[[anaphoral]]
+                                 UtfConverter::toUtf8(refx), 
                                  tr.second);
     }
   }

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -2285,8 +2285,10 @@ Transfer::applyRule()
     if(useBilingual && preBilingual == false)
     {
       tr = fstp.biltransWithQueue(*tmpword[i], false);
+      wstring refx;
       word[i] = new TransferWord(UtfConverter::toUtf8(*tmpword[i]),
                                  UtfConverter::toUtf8(tr.first),
+                                 UtfConverter::toUtf8(refx), //[[anaphora]]
                                  tr.second);
     }
     else if(preBilingual) //add for cr? [[anaphora]]
@@ -2346,13 +2348,16 @@ Transfer::applyRule()
       tr = pair<wstring, int>(tl, false);
       word[i] = new TransferWord(UtfConverter::toUtf8(sl),
                                  UtfConverter::toUtf8(tr.first),
+                                 UtfConverter::toUtf8(ref), //[[anaphora]]
                                  tr.second);
     }
     else // neither useBilingual nor preBilingual (sl==tl) [[anaphora]] add for ref?
     {
       tr = pair<wstring, int>(*tmpword[i], false);
+      wstring refx;
       word[i] = new TransferWord(UtfConverter::toUtf8(*tmpword[i]),
                                  UtfConverter::toUtf8(tr.first),
+                                 UtfConverter::toUtf8(refx), //[[anaphoral]]
                                  tr.second);
     }
   }

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -2093,6 +2093,8 @@ Transfer::transfer(FILE *in, FILE *out)
           {
             wstring sl;
             wstring tl;
+            wstring ref; //[[anaphora]]
+
             int seenSlash = 0;
             for(wstring::const_iterator it = tmpword[0]->begin(); it != tmpword[0]->end(); it++)
             {
@@ -2104,11 +2106,17 @@ Transfer::transfer(FILE *in, FILE *out)
                   it++;
                   sl.push_back(*it);
                 }
-                else
+                else if(seenSlash == 1)
                 {
                   tl.push_back(*it);
                   it++;
                   tl.push_back(*it);
+                }
+                else //[[anaphora]]
+                {
+                  ref.push_back(*it);
+                  it++;
+                  ref.push_back(*it);
                 }
                 continue;
               }
@@ -2125,13 +2133,17 @@ Transfer::transfer(FILE *in, FILE *out)
               {
                 tl.push_back(*it);
               }
-              else if(seenSlash > 1)
+              else if(seenSlash == 2) //[[anaphora]]
+              {
+                ref.push_back(*it);
+              }
+              else if(seenSlash > 2)
               {
                 break;
               }
             }
             //tmpword[0]->assign(sl);
-            tr = pair<wstring, int>(tl, false);
+            tr = pair<wstring, int>(tl, false); // [[anaphora]] what is tr?
             //wcerr << L"pb: " << *tmpword[0] << L" :: " << sl << L" >> " << tl << endl ;
           }
           else
@@ -2281,6 +2293,8 @@ Transfer::applyRule()
     {
       wstring sl;
       wstring tl;
+      wstring ref; //[[anaphora]]
+
       int seenSlash = 0;
       for(wstring::const_iterator it = tmpword[i]->begin(); it != tmpword[i]->end(); it++)
       {
@@ -2292,11 +2306,17 @@ Transfer::applyRule()
             it++;
             sl.push_back(*it);
           }
-          else
+          else if(seenSlash == 1)
           {
             tl.push_back(*it);
             it++;
             tl.push_back(*it);
+          }
+          else
+          {
+            ref.push_back(*it);
+            it++;
+            ref.push_back(*it);
           }
           continue;
         }
@@ -2314,7 +2334,11 @@ Transfer::applyRule()
         {
           tl.push_back(*it);
         }
-        else if(seenSlash > 1)
+        else if(seenSlash == 2) //[[anaphora]]
+        {
+          ref.push_back(*it);
+        }
+        else if(seenSlash > 2)
         {
           break;
         }
@@ -2324,7 +2348,7 @@ Transfer::applyRule()
                                  UtfConverter::toUtf8(tr.first),
                                  tr.second);
     }
-    else // neither useBilingual nor preBilingual (sl==tl)
+    else // neither useBilingual nor preBilingual (sl==tl) [[anaphora]] add for ref?
     {
       tr = pair<wstring, int>(*tmpword[i], false);
       word[i] = new TransferWord(UtfConverter::toUtf8(*tmpword[i]),

--- a/apertium/transfer.dtd
+++ b/apertium/transfer.dtd
@@ -364,7 +364,7 @@ representing a lexical form in the matched pattern
 
 <!ELEMENT clip EMPTY>
 <!ATTLIST clip pos CDATA #REQUIRED
-               side (sl|tl) #REQUIRED
+               side (sl|tl|ref) #REQUIRED
                part CDATA #REQUIRED
                queue CDATA #IMPLIED
                link-to CDATA #IMPLIED
@@ -377,7 +377,7 @@ representing a lexical form in the matched pattern
          inside the rule;
 
       * 'side' is used to select a source-language ('sl') or a
-        target-language ('tl') clip
+        target-language ('tl') or the reference ('ref') clip
 
       * the value of 'part' is the name of an attribute defined in
         def-attrs, but may take also the values 'lem' (referring to

--- a/apertium/transfer_instr.h
+++ b/apertium/transfer_instr.h
@@ -25,6 +25,7 @@ enum TransferInstrType
 {
   ti_clip_sl,
   ti_clip_tl,
+  ti_clip_ref,
   ti_var,
   ti_lit_tag,
   ti_lit,
@@ -32,8 +33,10 @@ enum TransferInstrType
   ti_get_case_from,
   ti_case_of_sl,
   ti_case_of_tl,
+  ti_case_of_ref,
   ti_linkto_sl,
   ti_linkto_tl,
+  ti_linkto_ref,
   ti_lu_count
 };
 


### PR DESCRIPTION
These changes are made to add a side "ref" to a Lexical Unit and to make it possible to clip side ref.

The apertium-anaphora module adds the antecedent for an anaphor on the side ref and in transfer, the output word is changed based on the antecedent in side "ref" and hence we need to add the ability to clip side ref.