### PR TITLE
Show rule line number in transfer/interchunk/postchunk -t (tracing)

### DIFF
--- a/apertium/interchunk.cc
+++ b/apertium/interchunk.cc
@@ -181,15 +181,17 @@ Interchunk::readInterchunk(string const &in)
 void
 Interchunk::collectRules(xmlNode *localroot)
 {
-  for(xmlNode *i = localroot->children; i != NULL; i = i->next)
+  for(xmlNode *rule = localroot->children; rule != NULL; rule = rule->next)
   {
-    if(i->type == XML_ELEMENT_NODE)
+    if(rule->type == XML_ELEMENT_NODE)
     {
-      for(xmlNode *j = i->children; ; j = j->next)
+      size_t line = rule->line;
+      for(xmlNode *rulechild = rule->children; ; rulechild = rulechild->next)
       {
-        if(j->type == XML_ELEMENT_NODE && !xmlStrcmp(j->name, (const xmlChar *) "action"))
+        if(rulechild->type == XML_ELEMENT_NODE && !xmlStrcmp(rulechild->name, (const xmlChar *) "action"))
         {
-          rule_map.push_back(j);
+          rule_map.push_back(rulechild);
+          rule_lines.push_back(line);
           break;
         }
       }
@@ -1456,12 +1458,13 @@ Interchunk::interchunk(FILE *in, FILE *out)
     int val = ms.classifyFinals(me->getFinals());
     if(val != -1)
     {
+      size_t lastrule_line = rule_lines[val-1];
       lastrule = rule_map[val-1];
       last = input_buffer.getPos();
 
       if(trace)
       {
-        wcerr << endl << L"apertium-interchunk: Rule " << val << L" ";
+        wcerr << endl << L"apertium-interchunk: Rule " << val << L" line " << lastrule_line << L" ";
         for (unsigned int ind = 0; ind < tmpword.size(); ind++)
         {
           if (ind != 0)

--- a/apertium/interchunk.h
+++ b/apertium/interchunk.h
@@ -51,6 +51,7 @@ private:
   map<string, set<string, Ltstr>, Ltstr> listslow;
   vector<xmlNode *> macro_map;
   vector<xmlNode *> rule_map;
+  vector<size_t> rule_lines;
   xmlDoc *doc;
   xmlNode *root_element;
   InterchunkWord **word;

--- a/apertium/postchunk.cc
+++ b/apertium/postchunk.cc
@@ -182,15 +182,17 @@ Postchunk::readPostchunk(string const &in)
 void
 Postchunk::collectRules(xmlNode *localroot)
 {
-  for(xmlNode *i = localroot->children; i != NULL; i = i->next)
+  for(xmlNode *rule = localroot->children; rule != NULL; rule = rule->next)
   {
-    if(i->type == XML_ELEMENT_NODE)
+    if(rule->type == XML_ELEMENT_NODE)
     {
-      for(xmlNode *j = i->children; ; j = j->next)
+      size_t line = rule->line;
+      for(xmlNode *rulechild = rule->children; ; rulechild = rulechild->next)
       {
-        if(j->type == XML_ELEMENT_NODE && !xmlStrcmp(j->name, (const xmlChar *) "action"))
+        if(rulechild->type == XML_ELEMENT_NODE && !xmlStrcmp(rulechild->name, (const xmlChar *) "action"))
         {
-          rule_map.push_back(j);
+          rule_map.push_back(rulechild);
+          rule_lines.push_back(line);
           break;
         }
       }
@@ -1617,12 +1619,13 @@ Postchunk::postchunk(FILE *in, FILE *out)
     int val = ms.classifyFinals(me->getFinals());
     if(val != -1)
     {
+      size_t lastrule_line = rule_lines[val-1];
       lastrule = rule_map[val-1];
       last = input_buffer.getPos();
 
       if(trace)
       {
-        wcerr << endl << L"apertium-postchunk: Rule " << val << L" ";
+        wcerr << endl << L"apertium-postchunk: Rule " << val << L" line " << lastrule_line << L" ";
         for (unsigned int ind = 0; ind < tmpword.size(); ind++)
         {
           if (ind != 0)

--- a/apertium/postchunk.h
+++ b/apertium/postchunk.h
@@ -50,6 +50,7 @@ private:
   map<string, set<string, Ltstr>, Ltstr> listslow;
   vector<xmlNode *> macro_map;
   vector<xmlNode *> rule_map;
+  vector<size_t> rule_lines;
   xmlDoc *doc;
   xmlNode *root_element;
   InterchunkWord **word;

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -240,15 +240,17 @@ Transfer::readTransfer(string const &in)
 void
 Transfer::collectRules(xmlNode *localroot)
 {
-  for(xmlNode *i = localroot->children; i != NULL; i = i->next)
+  for(xmlNode *rule = localroot->children; rule != NULL; rule = rule->next)
   {
-    if(i->type == XML_ELEMENT_NODE)
+    if(rule->type == XML_ELEMENT_NODE)
     {
-      for(xmlNode *j = i->children; ; j = j->next)
+      size_t line = rule->line;
+      for(xmlNode *rulechild = rule->children; ; rulechild = rulechild->next)
       {
-        if(j->type == XML_ELEMENT_NODE && !xmlStrcmp(j->name, (const xmlChar *) "action"))
+        if(rulechild->type == XML_ELEMENT_NODE && !xmlStrcmp(rulechild->name, (const xmlChar *) "action"))
         {
-          rule_map.push_back(j);
+          rule_map.push_back(rulechild);
+          rule_lines.push_back(line);
           break;
         }
       }
@@ -2196,13 +2198,14 @@ Transfer::transfer(FILE *in, FILE *out)
     int val = ms.classifyFinals(me->getFinals(), banned_rules);
     if(val != -1)
     {
+      size_t lastrule_line = rule_lines[val-1];
       lastrule = rule_map[val-1];
       lastrule_id = val;
       last = input_buffer.getPos();
 
       if(trace)
       {
-        wcerr << endl << L"apertium-transfer: Rule " << val << L" ";
+        wcerr << endl << L"apertium-transfer: Rule " << val << L" line " << lastrule_line << L" ";
         for (unsigned int ind = 0; ind < tmpword.size(); ind++)
         {
           if (ind != 0)

--- a/apertium/transfer.h
+++ b/apertium/transfer.h
@@ -51,6 +51,7 @@ private:
   map<string, set<string, Ltstr>, Ltstr> listslow;
   vector<xmlNode *> macro_map;
   vector<xmlNode *> rule_map;
+  vector<size_t> rule_lines;
   xmlDoc *doc;
   xmlNode *root_element;
   TransferWord **word;


### PR DESCRIPTION
Before:
```
apertium-interchunk: Rule 28 n_n<n><m><sg><def>{^rett<n><m><sg><ind><cmp>$^gang<n><m><sg><def>$}                                                                                    
```

After:
```
apertium-interchunk: Rule 28 line 1399 n_n<n><m><sg><def>{^rett<n><m><sg><ind><cmp>$^gang<n><m><sg><def>$}                                                                                    
```
