### PR TITLE
add debug modes for -recursive and -anaphora

### DIFF
--- a/apertium/modes2debugmodes.xsl
+++ b/apertium/modes2debugmodes.xsl
@@ -107,6 +107,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
       <xsl:when test="starts-with($p, 'lsx-proc')">
         <xsl:text>-autoseq</xsl:text>
       </xsl:when>
+      <xsl:when test="starts-with($p, 'rtx-proc')">
+        <xsl:text>-transfer</xsl:text>
+      </xsl:when>
+      <xsl:when test="starts-with($p, 'apertium-anaphora')">
+        <xsl:text>-anaph</xsl:text>
+      </xsl:when>
       <xsl:otherwise>
         <xsl:text>-NAMEME</xsl:text>
       </xsl:otherwise>
@@ -131,6 +137,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
       </xsl:when>
       <xsl:when test="starts-with($p, 'apertium-postchunk')">
         <xsl:text> -t</xsl:text>
+      </xsl:when>
+      <xsl:when test="starts-with($p, 'rtx-proc')">
+        <xsl:text> -r</xsl:text>
+      </xsl:when>
+      <xsl:when test="starts-with($p, 'apertium-anaphora')">
+        <xsl:text> -d</xsl:text>
       </xsl:when>
       <xsl:otherwise>
         <xsl:text></xsl:text>


### PR DESCRIPTION
This adds `rtx-proc` and `apertium-anaphora` to `modes2debugmodes.xsl`.