### PR TITLE
Secondary tags in transfer

### DIFF
--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -316,7 +316,7 @@ Transfer::evalString(xmlNode *element)
               if(in_let_var)
               {
                   string temp_sl_secondary_tags = word[ti.getPos()]->source(attr_items["sectags"], ti.getCondition());
-                  var_secondary_tags[var_val] = temp_sl_secondary_tags;
+                  var_secondary_tags[var_val].append(temp_sl_secondary_tags);
                   if(trace)
                   {
                     wcerr << "\nAdding secondary tags: " << temp_sl_secondary_tags << " with variable name:" << var_val << " in var_secondary_tags.\n\n";
@@ -324,7 +324,7 @@ Transfer::evalString(xmlNode *element)
               }
               else if(in_out_lu)
               {
-                  secondary_tags = word[ti.getPos()]->source(attr_items["sectags"], ti.getCondition());
+                  secondary_tags.append(word[ti.getPos()]->source(attr_items["sectags"], ti.getCondition()));
               }
           }
             
@@ -340,7 +340,7 @@ Transfer::evalString(xmlNode *element)
               if(in_let_var)
               {
                   string temp_tl_secondary_tags = word[ti.getPos()]->target(attr_items["sectags"], ti.getCondition());
-                  var_secondary_tags[var_val] = temp_tl_secondary_tags;
+                  var_secondary_tags[var_val].append(temp_tl_secondary_tags);
                   
                   if(trace)
                   {
@@ -349,7 +349,7 @@ Transfer::evalString(xmlNode *element)
               }
               else if(in_out_lu)
               {
-                  secondary_tags = word[ti.getPos()]->target(attr_items["sectags"], ti.getCondition());
+                  secondary_tags.append(word[ti.getPos()]->target(attr_items["sectags"], ti.getCondition()));
               }
           }
             
@@ -1069,6 +1069,8 @@ Transfer::processLet(xmlNode *localroot)
     string const val = (const char *) leftSide->properties->children->content;
     
     var_val = val; //current variable name - need it in evalString
+    var_secondary_tags[var_val].clear();
+    
     variables[val] = evalString(rightSide);
       
     in_let_var = false;

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -448,7 +448,7 @@ Transfer::evalString(xmlNode *element)
 
       case ti_var:
         secondary_tags.append(var_secondary_tags[ti.getContent()]); //append secondary tags of this variable into secondary_tags
-        /*
+        
         if(var_has_lemq[ti.getContent()])
         {
           string var_content = variables[ti.getContent()];
@@ -463,18 +463,12 @@ Transfer::evalString(xmlNode *element)
             }
             else if(var_content[index] == '\\')
             {
-              var_content_with_sectags.push_back(var_content[index]);
               index++;
-              var_content_with_sectags.push_back(var_content[index]);
               continue;
-            }
-            else
-            {
-              var_content_with_sectags.push_back(var_content[index]);
             }
           }
 
-          var_content_with_sectags.append(secondary_tags).append(var_content.substr(lemq_position, string::npos));
+          var_content_with_sectags = var_content.substr(0,lemq_position).append(secondary_tags).append(var_content.substr(lemq_position, string::npos));
           
           //cout << "\n###VARSTAGS::" << var_content_with_sectags << "::####\n";
           
@@ -482,7 +476,7 @@ Transfer::evalString(xmlNode *element)
           
           return var_content_with_sectags;
         }
-         */
+        
         
         return variables[ti.getContent()];
 

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -315,7 +315,7 @@ Transfer::evalString(xmlNode *element)
           {
               if(in_let_var)
               {
-                  string temp_sl_secondary_tags = word[ti.getPos()]->source(attr_items["stags"], ti.getCondition());
+                  string temp_sl_secondary_tags = word[ti.getPos()]->source(attr_items["sectags"], ti.getCondition());
                   var_secondary_tags[var_val] = temp_sl_secondary_tags;
                   if(trace)
                   {
@@ -324,7 +324,7 @@ Transfer::evalString(xmlNode *element)
               }
               else if(in_out_lu)
               {
-                  secondary_tags = word[ti.getPos()]->source(attr_items["stags"], ti.getCondition());
+                  secondary_tags = word[ti.getPos()]->source(attr_items["sectags"], ti.getCondition());
               }
           }
             
@@ -339,7 +339,7 @@ Transfer::evalString(xmlNode *element)
           {
               if(in_let_var)
               {
-                  string temp_tl_secondary_tags = word[ti.getPos()]->target(attr_items["stags"], ti.getCondition());
+                  string temp_tl_secondary_tags = word[ti.getPos()]->target(attr_items["sectags"], ti.getCondition());
                   var_secondary_tags[var_val] = temp_tl_secondary_tags;
                   
                   if(trace)
@@ -349,7 +349,7 @@ Transfer::evalString(xmlNode *element)
               }
               else if(in_out_lu)
               {
-                  secondary_tags = word[ti.getPos()]->target(attr_items["stags"], ti.getCondition());
+                  secondary_tags = word[ti.getPos()]->target(attr_items["sectags"], ti.getCondition());
               }
           }
             

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -449,7 +449,7 @@ Transfer::evalString(xmlNode *element)
       case ti_var:
         secondary_tags.append(var_secondary_tags[ti.getContent()]); //append secondary tags of this variable into secondary_tags
         
-        if(var_has_lemq[ti.getContent()])
+        if(var_has_lemq[ti.getContent()] && !secondary_tags.empty())
         {
           string var_content = variables[ti.getContent()];
           string var_content_with_sectags = "";

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -835,7 +835,7 @@ Transfer::processChunk(xmlNode *localroot)
         result.append(processTags(i));
         result.append("{");
       }
-      else if(!xmlStrcmp(i->name, (const xmlChar *) "lu")) //Need to add secondary tags here!
+      else if(!xmlStrcmp(i->name, (const xmlChar *) "lu"))
       {
         in_out_lu = true;
         stags.clear();

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -2437,8 +2437,6 @@ void
 Transfer::applyWord(wstring const &word_str)
 {
   ms.step(L'^');
-  
-  int secondary_flag = 0; //flag to recognise secondary tags
     
   for(unsigned int i = 0, limit = word_str.size(); i < limit; i++)
   {
@@ -2456,11 +2454,12 @@ Transfer::applyWord(wstring const &word_str)
       case L'<':
 	for(unsigned int j = i+1; j != limit; j++)
 	{
-      if(word_str[j] == L':') //if secondary tags reached, discard current tag
+      if(word_str[j] == L':') //if secondary tags reached, discard current tag and stop processing word
       {
-          secondary_flag = 1;
+          i = limit;
           break;
       }
+        
 	  if(word_str[j] == L'>')
 	  {
 	    int symbol = alphabet(word_str.substr(i, j-i+1));
@@ -2482,9 +2481,6 @@ Transfer::applyWord(wstring const &word_str)
 	ms.step(towlower(word_str[i]), any_char);
 	break;
     }
-    
-    if(secondary_flag == 1)
-        break; //stop processing word if secondary tags reached
   }
   ms.step(L'$');
 }

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -313,7 +313,9 @@ Transfer::evalString(xmlNode *element)
                   string temp_sl_stags = word[ti.getPos()]->source(attr_items["stags"], ti.getCondition());
                   var_stags[var_val] = temp_sl_stags;
                   if(trace)
+                  {
                     wcerr << "\nAdding secondary tags: " << temp_sl_stags << " with variable name:" << var_val << " in var_stags.\n\n";
+                  }
               }
               else if(in_out_lu)
               {
@@ -336,7 +338,9 @@ Transfer::evalString(xmlNode *element)
                   var_stags[var_val] = temp_tl_stags;
                   
                   if(trace)
+                  {
                       wcerr << "\nAdding secondary tags: " << temp_tl_stags << " with variable name:" << var_val << " in var_stags.\n\n";
+                  }
               }
               else if(in_out_lu)
               {

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -304,6 +304,12 @@ Transfer::evalString(xmlNode *element)
       case ti_clip_sl:
         if(checkIndex(element, ti.getPos(), lword))
         {
+          if(ti.getContent().compare("lem") == 0 || ti.getContent().compare("lemh") == 0) //only get secondary tags if we're getting the lemma from the word
+          {
+              stags = word[ti.getPos()]->source(attr_items["stags"], ti.getCondition());
+              //cout << "\n##SLSTAGS::" <<stags << "##SLSTAGS##\n";
+          }
+            
           return word[ti.getPos()]->source(attr_items[ti.getContent()], ti.getCondition());
         }
         break;
@@ -311,6 +317,12 @@ Transfer::evalString(xmlNode *element)
       case ti_clip_tl:
         if(checkIndex(element, ti.getPos(), lword))
         {
+          if(ti.getContent().compare("lem") == 0 || ti.getContent().compare("lemh") == 0)
+          {
+              stags = word[ti.getPos()]->target(attr_items["stags"], ti.getCondition());
+              //cout << "\n##TLSTAGS::" <<stags << "##TLSTAGS##\n";
+          }
+            
           return word[ti.getPos()]->target(attr_items[ti.getContent()], ti.getCondition());
         }
         break;
@@ -651,7 +663,7 @@ Transfer::processOut(xmlNode *localroot)
   {
     if(i->type == XML_ELEMENT_NODE)
     {
-      if(defaultAttrs == lu)
+      if(defaultAttrs == lu) //stream_modification TODO
       {
         if(!xmlStrcmp(i->name, (const xmlChar *) "lu"))
         {
@@ -793,8 +805,11 @@ Transfer::processChunk(xmlNode *localroot)
         result.append(processTags(i));
         result.append("{");
       }
-      else if(!xmlStrcmp(i->name, (const xmlChar *) "lu"))
+      else if(!xmlStrcmp(i->name, (const xmlChar *) "lu")) //Need to add secondary tags here!
       {
+          //cout << "\n%%OUTNOW%%\n";
+          stags.clear();
+          
         string myword;
         for(xmlNode *j = i->children; j != NULL; j = j->next)
         {
@@ -803,6 +818,9 @@ Transfer::processChunk(xmlNode *localroot)
             myword.append(evalString(j));
           }
         }
+          //cout << "\n###MYWORD###\n" << myword << "\n###MYWORD###\n";
+          myword.append(stags); //from the LU that the lem or lemh has come from
+          //cout << "\n###WITHSTAGS###\n" << myword << "\n###WITHSTAGS###\n";
         if(myword != "")
         {
           result.append("^");
@@ -810,7 +828,7 @@ Transfer::processChunk(xmlNode *localroot)
           result.append("$");
         }
       }
-      else if(!xmlStrcmp(i->name, (const xmlChar *) "mlu"))
+      else if(!xmlStrcmp(i->name, (const xmlChar *) "mlu")) //stream modification TODO
       {
         bool first_time = true;
         string myword;

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -448,7 +448,7 @@ Transfer::evalString(xmlNode *element)
 
       case ti_var:
         secondary_tags.append(var_secondary_tags[ti.getContent()]); //append secondary tags of this variable into secondary_tags
-        
+        /*
         if(var_has_lemq[ti.getContent()])
         {
           string var_content = variables[ti.getContent()];
@@ -482,6 +482,7 @@ Transfer::evalString(xmlNode *element)
           
           return var_content_with_sectags;
         }
+         */
         
         return variables[ti.getContent()];
 

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -292,6 +292,11 @@ Transfer::checkIndex(xmlNode *element, int index, int limit)
   return true;
 }
 
+bool
+Transfer::gettingLemmaFromWord(TransferInstr tri)
+{
+    return (tri.getContent().compare("lem") == 0 || tri.getContent().compare("lemh") == 0);
+}
 
 string
 Transfer::evalString(xmlNode *element)
@@ -306,20 +311,20 @@ Transfer::evalString(xmlNode *element)
       case ti_clip_sl:
         if(checkIndex(element, ti.getPos(), lword))
         {
-          if(ti.getContent().compare("lem") == 0 || ti.getContent().compare("lemh") == 0) //only get secondary tags if we're getting the lemma from the word
+          if(gettingLemmaFromWord(ti))
           {
               if(in_let_var)
               {
-                  string temp_sl_stags = word[ti.getPos()]->source(attr_items["stags"], ti.getCondition());
-                  var_stags[var_val] = temp_sl_stags;
+                  string temp_sl_secondary_tags = word[ti.getPos()]->source(attr_items["stags"], ti.getCondition());
+                  var_secondary_tags[var_val] = temp_sl_secondary_tags;
                   if(trace)
                   {
-                    wcerr << "\nAdding secondary tags: " << temp_sl_stags << " with variable name:" << var_val << " in var_stags.\n\n";
+                    wcerr << "\nAdding secondary tags: " << temp_sl_secondary_tags << " with variable name:" << var_val << " in var_secondary_tags.\n\n";
                   }
               }
               else if(in_out_lu)
               {
-                  stags = word[ti.getPos()]->source(attr_items["stags"], ti.getCondition());
+                  secondary_tags = word[ti.getPos()]->source(attr_items["stags"], ti.getCondition());
               }
           }
             
@@ -330,21 +335,21 @@ Transfer::evalString(xmlNode *element)
       case ti_clip_tl:
         if(checkIndex(element, ti.getPos(), lword))
         {
-          if(ti.getContent().compare("lem") == 0 || ti.getContent().compare("lemh") == 0)
+          if(gettingLemmaFromWord(ti))
           {
               if(in_let_var)
               {
-                  string temp_tl_stags = word[ti.getPos()]->target(attr_items["stags"], ti.getCondition());
-                  var_stags[var_val] = temp_tl_stags;
+                  string temp_tl_secondary_tags = word[ti.getPos()]->target(attr_items["stags"], ti.getCondition());
+                  var_secondary_tags[var_val] = temp_tl_secondary_tags;
                   
                   if(trace)
                   {
-                      wcerr << "\nAdding secondary tags: " << temp_tl_stags << " with variable name:" << var_val << " in var_stags.\n\n";
+                      wcerr << "\nAdding secondary tags: " << temp_tl_secondary_tags << " with variable name:" << var_val << " in var_secondary_tags.\n\n";
                   }
               }
               else if(in_out_lu)
               {
-                  stags = word[ti.getPos()]->target(attr_items["stags"], ti.getCondition());
+                  secondary_tags = word[ti.getPos()]->target(attr_items["stags"], ti.getCondition());
               }
           }
             
@@ -402,7 +407,7 @@ Transfer::evalString(xmlNode *element)
         break;
 
       case ti_var:
-        stags.append(var_stags[ti.getContent()]); //append secondary tags of this variable into stags
+        secondary_tags.append(var_secondary_tags[ti.getContent()]); //append secondary tags of this variable into secondary_tags
         return variables[ti.getContent()];
 
       case ti_lit_tag:
@@ -694,7 +699,7 @@ Transfer::processOut(xmlNode *localroot)
         if(!xmlStrcmp(i->name, (const xmlChar *) "lu"))
         {
           in_out_lu = true;
-          stags.clear();
+          secondary_tags.clear();
             
           string myword;
           for(xmlNode *j = i->children; j != NULL; j = j->next)
@@ -707,7 +712,7 @@ Transfer::processOut(xmlNode *localroot)
             
           in_out_lu = false;
 
-          myword.append(stags); //from the LU that the lem or lemh has come from - stags is added in evalString
+          myword.append(secondary_tags); //from the LU that the lem or lemh has come from - secondary_tags is added in evalString
           
           if(myword != "")
           {
@@ -842,7 +847,7 @@ Transfer::processChunk(xmlNode *localroot)
       else if(!xmlStrcmp(i->name, (const xmlChar *) "lu"))
       {
         in_out_lu = true;
-        stags.clear();
+        secondary_tags.clear();
           
         string myword;
         for(xmlNode *j = i->children; j != NULL; j = j->next)
@@ -854,7 +859,7 @@ Transfer::processChunk(xmlNode *localroot)
         }
           in_out_lu = false;
 
-          myword.append(stags); //from the LU that the lem or lemh has come from - stags is added in evalString
+          myword.append(secondary_tags); //from the LU that the lem or lemh has come from - secondary_tags is added in evalString
 
         if(myword != "")
         {

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -2437,6 +2437,9 @@ void
 Transfer::applyWord(wstring const &word_str)
 {
   ms.step(L'^');
+  
+  int secondary_flag = 0; //flag to recognise secondary tags
+    
   for(unsigned int i = 0, limit = word_str.size(); i < limit; i++)
   {
     switch(word_str[i])
@@ -2453,6 +2456,11 @@ Transfer::applyWord(wstring const &word_str)
       case L'<':
 	for(unsigned int j = i+1; j != limit; j++)
 	{
+      if(word_str[j] == L':') //if secondary tags reached, discard current tag
+      {
+          secondary_flag = 1;
+          break;
+      }
 	  if(word_str[j] == L'>')
 	  {
 	    int symbol = alphabet(word_str.substr(i, j-i+1));
@@ -2474,6 +2482,9 @@ Transfer::applyWord(wstring const &word_str)
 	ms.step(towlower(word_str[i]), any_char);
 	break;
     }
+    
+    if(secondary_flag == 1)
+        break; //stop processing word if secondary tags reached
   }
   ms.step(L'$');
 }

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -316,7 +316,6 @@ Transfer::evalString(xmlNode *element)
             if(in_lu)
             {
                 secondary_tags.append(word[ti.getPos()]->source(attr_items["sectags"], ti.getCondition()));
-//               wcout << "\n###EVALSLSTAGS::" << secondary_tags << "::\n";
             }
             else if(in_let_var)
             {
@@ -330,7 +329,6 @@ Transfer::evalString(xmlNode *element)
           }
            else if(ti.getContent().compare("lemq") == 0)
            {
-  //           cout << "\nLEMQ!\n";
              if(in_lu)
              {
                string sectags_lemq = secondary_tags;
@@ -354,16 +352,9 @@ Transfer::evalString(xmlNode *element)
         {
           if(gettingLemmaFromWord(ti.getContent()))
           {
-  //          cout << "\nLEM or LEMH\n";
- //           if(in_lu)
- //               cout <<"\nINLU!\n";
- //           else
- //               cout <<"\nNOTINLU!\n";
-            
             if(in_lu)
             {
               secondary_tags.append(word[ti.getPos()]->target(attr_items["sectags"], ti.getCondition()));
-              //wcout << "\n###:: "<< word[ti.getPos()]->target(attr_items[ti.getContent()], ti.getCondition()) << "EVALTLSTAGS::" << secondary_tags << "::\n";
             }
             else if(in_let_var)
             {
@@ -378,7 +369,6 @@ Transfer::evalString(xmlNode *element)
           }
           else if(ti.getContent().compare("lemq") == 0)
           {
-            //cout << "\nLEMQ!\n";
             if(in_lu)
             {
               string sectags_lemq = secondary_tags;
@@ -447,7 +437,7 @@ Transfer::evalString(xmlNode *element)
         break;
 
       case ti_var:
-        secondary_tags.append(var_secondary_tags[ti.getContent()]); //append secondary tags of this variable into secondary_tags
+        secondary_tags.append(var_secondary_tags[ti.getContent()]);
         
         if(var_has_lemq[ti.getContent()] && !secondary_tags.empty())
         {
@@ -469,8 +459,6 @@ Transfer::evalString(xmlNode *element)
           }
 
           var_content_with_sectags = var_content.substr(0,lemq_position).append(secondary_tags).append(var_content.substr(lemq_position, string::npos));
-          
-          //cout << "\n###VARSTAGS::" << var_content_with_sectags << "::####\n";
           
           secondary_tags.clear();
           
@@ -691,9 +679,8 @@ Transfer::evalString(xmlNode *element)
     }
     
     in_lu = false;
-    myword.append(secondary_tags); //from the LU that the lem or lemh has come from - secondary_tags is added in evalString
+    myword.append(secondary_tags);
       
-      //wcout << "\n###EVALSTRINGMYWORD::" << myword << "::###\n";
     if(myword != "")
     {
       return "^"+myword+"$";
@@ -727,8 +714,7 @@ Transfer::evalString(xmlNode *element)
         }
         
         in_lu = false;
-        myword.append(secondary_tags); //from the LU that the lem or lemh has come from
-        //wcout << "\n###EVALMLUMYWORD::" << myword << "::###\n";
+        myword.append(secondary_tags);
 
 	if(!first_time)
 	{
@@ -796,8 +782,7 @@ Transfer::processOut(xmlNode *localroot)
             
           in_lu = false;
 
-          myword.append(secondary_tags); //from the LU that the lem or lemh has come from - secondary_tags is added in evalString
-          //wcout << "\n###OUTMYWORD::" << myword << "::###\n";
+          myword.append(secondary_tags);
           if(myword != "")
           {
             fputwc_unlocked(L'^', output);
@@ -826,7 +811,7 @@ Transfer::processOut(xmlNode *localroot)
 	      }
         
         in_lu = false;
-        myword.append(secondary_tags); //from the LU that the lem or lemh has come from
+        myword.append(secondary_tags);
 
 	      if(!first_time)
 	      {
@@ -842,7 +827,7 @@ Transfer::processOut(xmlNode *localroot)
 	          first_time = false;
                 }
 	      }
-//            wcout << "\n###OUTMLUMYWORD::" << myword << "::###\n";
+
 	      fputws_unlocked(UtfConverter::fromUtf8(myword).c_str(), output);
 	    }
 	  }
@@ -946,12 +931,11 @@ Transfer::processChunk(xmlNode *localroot)
           if(j->type == XML_ELEMENT_NODE)
           {
             myword.append(evalString(j));
-   //          wcout << "\n###CHUNKMYWORD::" << myword << "::###" << secondary_tags << "::\n";
           }
         }
           in_lu = false;
 
-          myword.append(secondary_tags); //from the LU that the lem or lemh has come from - secondary_tags is added in evalString
+          myword.append(secondary_tags);
           
         if(myword != "")
         {
@@ -977,12 +961,11 @@ Transfer::processChunk(xmlNode *localroot)
               if(k->type == XML_ELEMENT_NODE)
               {
                 mylocalword.append(evalString(k));
-   //               wcout << "\n###CHUNKMLUMLOCALYWORD::" << mylocalword << "::###\n";
               }
             }
             
             in_lu = false;
-            mylocalword.append(secondary_tags); //from the LU that the lem or lemh has come from
+            mylocalword.append(secondary_tags);
 
             if(!first_time)
             {
@@ -1124,7 +1107,7 @@ Transfer::processLet(xmlNode *localroot)
     {
       case ti_var:
         in_let_var = true;
-        var_val = ti.getContent(); //current variable name - need it in evalString
+        var_val = ti.getContent();
 
         var_secondary_tags[var_val].clear();
         var_has_lemq[var_val] = false;
@@ -1175,7 +1158,7 @@ Transfer::processLet(xmlNode *localroot)
     
     string const val = (const char *) leftSide->properties->children->content;
     
-    var_val = val; //current variable name - need it in evalString
+    var_val = val;
     var_secondary_tags[var_val].clear();
     var_has_lemq[var_val] = false;
     

--- a/apertium/transfer.h
+++ b/apertium/transfer.h
@@ -63,13 +63,13 @@ private:
   vector<wstring *> tmpblank;
   
   //for secondary tags
-  bool in_out_lu; //flag to denote that lu in out is being processed
-  string secondary_tags; //stores secondary tags of the LU that is being output
+  bool in_lu; //flag to denote that lu is being processed
+  string secondary_tags; //stores secondary tags of the LU that is being processed
   bool in_let_var; //flag to denote that a var in let is being processed
   string var_val; //stores the name of the variable being processed
   map <string, string> var_secondary_tags; //map variable name to secondary tags of the word it takes lem/lemh from
   
-  bool gettingLemmaFromWord(TransferInstr tri);
+  bool gettingLemmaFromWord(string attr);
     
   FSTProcessor fstp;
   FSTProcessor extended;

--- a/apertium/transfer.h
+++ b/apertium/transfer.h
@@ -65,9 +65,10 @@ private:
   //for secondary tags
   bool in_lu; //flag to denote that lu is being processed
   string secondary_tags; //stores secondary tags of the LU that is being processed
-  bool in_let_var; //flag to denote that a var in let is being processed
-  string var_val; //stores the name of the variable being processed
+  bool in_let_var; //flag to denote that a var in let is being processed (or in append)
+  string var_val; //stores the name of the variable being processed (in let or append)
   map <string, string> var_secondary_tags; //map variable name to secondary tags of the word it takes lem/lemh from
+  map <string, bool> var_has_lemq;
   
   bool gettingLemmaFromWord(string attr);
     

--- a/apertium/transfer.h
+++ b/apertium/transfer.h
@@ -62,7 +62,12 @@ private:
   vector<wstring *> tmpword;
   vector<wstring *> tmpblank;
   
+  //for secondary tags
+  bool in_out_lu; //flag to denote that lu in out is being processed
   string stags; //stores secondary tags of the LU that is being output
+  bool in_let_var; //flag to denote that a var in let is being processed
+  string var_val; //stores the name of the variable being processed
+  map <string, string> var_stags; //map variable name to secondary tags of the word it takes lem/lemh from
     
   FSTProcessor fstp;
   FSTProcessor extended;

--- a/apertium/transfer.h
+++ b/apertium/transfer.h
@@ -61,7 +61,9 @@ private:
   Buffer<TransferToken> input_buffer;
   vector<wstring *> tmpword;
   vector<wstring *> tmpblank;
-
+  
+  string stags; //stores secondary tags of the LU that is being output
+    
   FSTProcessor fstp;
   FSTProcessor extended;
   bool isExtended;

--- a/apertium/transfer.h
+++ b/apertium/transfer.h
@@ -68,7 +68,7 @@ private:
   bool in_let_var; //flag to denote that a var in let is being processed (or in append)
   string var_val; //stores the name of the variable being processed (in let or append)
   map <string, string> var_secondary_tags; //map variable name to secondary tags of the word it takes lem/lemh from
-  map <string, bool> var_has_lemq;
+  map <string, bool> var_has_lemq; //map variable name to bool->true if variable clips lemq
   
   bool gettingLemmaFromWord(string attr);
     

--- a/apertium/transfer.h
+++ b/apertium/transfer.h
@@ -64,10 +64,12 @@ private:
   
   //for secondary tags
   bool in_out_lu; //flag to denote that lu in out is being processed
-  string stags; //stores secondary tags of the LU that is being output
+  string secondary_tags; //stores secondary tags of the LU that is being output
   bool in_let_var; //flag to denote that a var in let is being processed
   string var_val; //stores the name of the variable being processed
-  map <string, string> var_stags; //map variable name to secondary tags of the word it takes lem/lemh from
+  map <string, string> var_secondary_tags; //map variable name to secondary tags of the word it takes lem/lemh from
+  
+  bool gettingLemmaFromWord(TransferInstr tri);
     
   FSTProcessor fstp;
   FSTProcessor extended;

--- a/apertium/transfer_data.cc
+++ b/apertium/transfer_data.cc
@@ -50,7 +50,8 @@ TransferData::TransferData()
   attr_items[L"lemq"] = L"\\#[- _][^<]+";
   attr_items[L"lemh"] = L"^(([^<#]|\"\\<\"|\"\\#\")+)";
   attr_items[L"whole"] = L"(.+)";
-  attr_items[L"tags"] = L"((<[^>]+>)+)";
+  attr_items[L"tags"] = L"((<[^:>]+>)+)"; //match all tags excluding secondary tags
+  attr_items[L"stags"] = L"((<[^>]+:[^>]+>)+)"; //match all secondary tags
   attr_items[L"chname"] = L"({([^/]+)\\/)"; // includes delimiters { and / !!!
   attr_items[L"chcontent"] = L"(\\{.+)";
   attr_items[L"content"] = L"(\\{.+)";

--- a/apertium/transfer_data.cc
+++ b/apertium/transfer_data.cc
@@ -51,7 +51,7 @@ TransferData::TransferData()
   attr_items[L"lemh"] = L"^(([^<#]|\"\\<\"|\"\\#\")+)";
   attr_items[L"whole"] = L"(.+)";
   attr_items[L"tags"] = L"((<[^:>]+>)+)"; //match all tags excluding secondary tags
-  attr_items[L"stags"] = L"((<[^>]+:[^>]+>)+)"; //match all secondary tags
+  attr_items[L"sectags"] = L"((<[^>]+:[^>]+>)+)"; //match all secondary tags
   attr_items[L"chname"] = L"({([^/]+)\\/)"; // includes delimiters { and / !!!
   attr_items[L"chcontent"] = L"(\\{.+)";
   attr_items[L"content"] = L"(\\{.+)";


### PR DESCRIPTION
- Secondary tags (sectags) are ignored while pattern matching for rules.
- Attribute "tags" (in t1x) gets only primary and not secondary tags. (Ensures no regression)
- "whole" gets the whole LU including secondary tags (could this be a problem?)
- New attribute "sectags" gets all secondary tags. (can be used in clip).
- Secondary tags are added in the output LU from the LU that the lem/lemh is clipped from.
- If the lem/lemh comes from a variable in the output then the stags come from the LU which the lemma comes from, by tracing its variable assignment in ```<let>```.
- **No regression**. Stream without secondary tags work as-is.
- Now works with MLUs.
- If there is a lemq in the LU, sectags appear before the lemq. Even if the lemq comes from a variable.
- Can't have unescaped $ in secondary tags as of now.
- Can clip "sectags" in chunk tags to use secondary information if needed interchunk.

Example Usage (Here the secondary tags show the surface form):
Input:
`
^El<det><def><m><pl><sf:Los>/The<det><def><m><pl><sf:Los>$ ^perro<n><m><pl><sf:perros>/dog<n><m><pl><sf:perros>$ ^de<pr><sf:del>/of<pr><sf:del>/from<pr><sf:del>$ ^el<det><def><m><sg><sf:del>/the<det><def><m><sg><sf:del>$ ^chico<n><m><sg><sf:chico>/boy<n><sg><sf:chico>$ ^correr<vblex><pri><p3><pl><sf:corren>/run<vblex><pri><p3><pl><sf:corren>$ ^rápido<adj><m><sg><sf:rápido>/fast<adj><sint><m><sg><sf:rápido>$ ^.<sent><sf:.>/.<sent><sf:.>$ ^.<sent><sf:.>/.<sent><sf:.>$[][
]
`

Output:
`
^Det_nom<SN><m><pl>{^the<det><def><3><sf:Los>$ ^dog<n><3><sf:perros>$}$ ^de<PREP>{^of<pr><sf:del>$}$ ^det_nom<SN><m><sg>{^the<det><def><3><sf:del>$ ^boy<n><3><sf:chico>$}$ ^verbcj<SV><vblex><pri><p3><pl>{^run<vblex><pres><sf:corren>$}$ ^adj<SA><m><sg>{^fast<adj><sint><sf:rápido>$}$^punt<sent>{^.<sent><sf:.>$}$^punt<sent>{^.<sent><sf:.>$}$[][
]
`