### PR TITLE
Wordbound blanks distribute to parts in pretransfer

### DIFF
--- a/apertium/pretransfer.h
+++ b/apertium/pretransfer.h
@@ -19,8 +19,9 @@
 #include <iostream>
 #include <lttoolbox/lt_locale.h>
 
+wstring storeAndWriteWblank(FILE *input, FILE *output);
 void readAndWriteUntil(FILE *input, FILE *output, int const charcode);
-void procWord(FILE *input, FILE *output, bool surface_forms, bool compound_sep);
+void procWord(FILE *input, FILE *output, bool surface_forms, bool compound_sep, wstring wblank);
 void processStream(FILE *input, FILE *output, bool null_flush, bool surface_forms, bool compound_sep);
 
 #endif

--- a/tests/pretransfer/__init__.py
+++ b/tests/pretransfer/__init__.py
@@ -84,11 +84,6 @@ class JoinGroupPretransferTest(PretransferTest):
     inputs =          ["[<div>]^a<vblex><pres>+c<po># b$",   "[<div>]^a<vblex><pres>+c<po>+d<po># b$"]
     expectedOutputs = ["[<div>]^a# b<vblex><pres>$ ^c<po>$", "[<div>]^a# b<vblex><pres>$ ^c<po>$ ^d<po>$"]
 
-
-# Proposed inline blank format:
-class InlineBlankPretransferTest(PretransferTest):
-    inputs =          ["[{<i>}]^a<vblex><pres>+c<po># b$",          "[{<i>}]^a<vblex><pres>+c<po>+d<po># b$"]
-    expectedOutputs = ["[{<i>}]^a# b<vblex><pres>$ [{<i>}]^c<po>$", "[{<i>}]^a# b<vblex><pres>$ [{<i>}]^c<po>$ [{<i>}]^d<po>$"]
-    @unittest.expectedFailure
-    def runTest(self):
-        super().runTest(self)
+class WordboundBlankTestPretransferTest(PretransferTest):
+    inputs =          ["[[t:i:abc123]]^a<vblex><pres>+c<po># b$", "[[t:i:xyz456]]^a<vblex><pres>+c<po>+d<po># b$"]
+    expectedOutputs = ["[[t:i:abc123]]^a# b<vblex><pres>$ [[t:i:abc123]]^c<po>$", "[[t:i:xyz456]]^a# b<vblex><pres>$ [[t:i:xyz456]]^c<po>$ [[t:i:xyz456]]^d<po>$"]


### PR DESCRIPTION
Pretty straightforward.
Turns an expected failure test into a passing one.

Examples:
```
Input:
[[t:i:abc123]]^a<vblex><pres>+c<po># b$

Output:
[[t:i:abc123]]^a# b<vblex><pres>$ [[t:i:abc123]]^c<po>$
```

```
Input:
[[t:i:xyz456]]^a<vblex><pres>+c<po>+d<po># b$

Output:
[[t:i:xyz456]]^a# b<vblex><pres>$ [[t:i:xyz456]]^c<po>$ [[t:i:xyz456]]^d<po>$
```