### PR TITLE
Parsing wblanks and prefix tags in the tagger

### DIFF
--- a/apertium/stream.cc
+++ b/apertium/stream.cc
@@ -76,6 +76,7 @@ StreamedType Stream::get() {
       case L'[':
         if (ThePreviousCase) {
           switch (ThePreviousCase->ThePreviousCase) {
+          case L'[':
           case L']':
           case L'$':
             break;
@@ -83,7 +84,7 @@ StreamedType Stream::get() {
             std::wstringstream Message;
             Message << L"unexpected '" << Character_ << L"' following '"
                     << ThePreviousCase->ThePreviousCase
-                    << L"', '[' expected to follow ']' or '$'";
+                    << L"', '[' expected to follow '[', ']' or '$'";
             throw wchar_t_Exception::Stream::UnexpectedCase(
                 Message_what(Message));
           }
@@ -103,6 +104,7 @@ StreamedType Stream::get() {
 
         switch (ThePreviousCase->ThePreviousCase) {
         case L'[':
+        case L']':
           push_back_Character(TheStreamedType, Lemma, Character_);
           ThePreviousCase = PreviousCaseType(Character_);
           continue;
@@ -110,7 +112,7 @@ StreamedType Stream::get() {
           std::wstringstream Message;
           Message << L"unexpected '" << Character_ << L"' following '"
                   << ThePreviousCase->ThePreviousCase
-                  << L"', ']' expected to follow '['";
+                  << L"', ']' expected to follow '[' or ']'";
           throw wchar_t_Exception::Stream::UnexpectedCase(
               Message_what(Message));
         }

--- a/apertium/stream.cc
+++ b/apertium/stream.cc
@@ -201,11 +201,20 @@ StreamedType Stream::get() {
               throw wchar_t_Exception::Stream::UnexpectedCharacter(
                   Message_what(Message));
             };
+            case L'<':
+              TheStreamedType.TheLexicalUnit->TheAnalyses.push_back(Analysis());
+              TheStreamedType.TheLexicalUnit->TheAnalyses.back()
+                .TheMorphemes.push_back(Morpheme());
+              TheStreamedType.TheLexicalUnit->TheAnalyses.back()
+                .TheMorphemes.back()
+                .TheTags.push_back(Tag());
+              ThePreviousCase = PreviousCaseType(Character_);
+              continue;
+                
             case L'[':
             case L']':
             case L'^':
             case L'#':
-            case L'<':
             case L'>':
             case L'+':
             case L'$': {
@@ -304,6 +313,7 @@ StreamedType Stream::get() {
           push_back_Character(TheStreamedType, Lemma, Character_);
           continue;
         case L'/':
+          break;
         case L'#':
           //std::wcerr << L"[306] Character: " << Character_ << L"||| Lemma: " << Lemma << std::endl ;
         case L'+':
@@ -312,8 +322,8 @@ StreamedType Stream::get() {
             Message << L"unexpected '" << Character_
                     << L"' immediately following '"
                     << ThePreviousCase->ThePreviousCase
-                    << L"', '<' expected to follow '[', to follow '>' "
-                       L"immediately, or to follow '#', '/' or '+' not "
+                    << L"', '<' expected to follow '[', '/', '>'"
+                       L"immediately, or to follow '#' or '+' not "
                        L"immediately";
             throw wchar_t_Exception::Stream::UnexpectedCase(
                 Message_what(Message));
@@ -321,18 +331,6 @@ StreamedType Stream::get() {
 
           break;
         case L'>':
-          if (!ThePreviousCase->isPreviousCharacter) {
-            std::wstringstream Message;
-            Message << L"unexpected '" << Character_
-                    << L"' not immediately following '"
-                    << ThePreviousCase->ThePreviousCase
-                    << L"', '<' expected to follow '[', to follow '>' "
-                       L"immediately, or to follow '#', '/' or '+' not "
-                       L"immediately";
-            throw wchar_t_Exception::Stream::UnexpectedCase(
-                Message_what(Message));
-          }
-
           break;
         default:
           std::wstringstream Message;
@@ -784,13 +782,11 @@ void Stream::push_back_Character(StreamedType &StreamedType_,
           .TheTags.back()
           .TheTag += Character_;
       break;
-    case L'>': {
-      std::wstringstream Message;
-      Message << L"unexpected '" << Character_ << L"' immediately following '"
-              << ThePreviousCase->ThePreviousCase << L"'";
-      throw wchar_t_Exception::Stream::UnexpectedCharacter(
-          Message_what(Message));
-    }
+    case L'>':
+      StreamedType_.TheLexicalUnit->TheAnalyses.back()
+          .TheMorphemes.back()
+          .TheLemma.push_back(Character_);
+      break;
     case L'#':
       StreamedType_.TheLexicalUnit->TheAnalyses.back()
           .TheMorphemes.back()


### PR DESCRIPTION
Changes made to the parser such that it parses wblanks as normal blanks, and also accepts prefix tags.

Example Input:
```
[[t:b:Z9eiLA]]^I/Prpers<prn><subj><p1><mf><sg>$ ^am/<test><test2>be<vbser><pres><p1><sg>$ [[t:b:QjZnxQ]]^David/<testl><testm>David<np><cog><sg>/<test1><test3>David<np><ant><m><sg>$[[t:b:QjZnxQ]]^./.<sent>$[]
```

Example Output:
```
[[t:b:Z9eiLA]]^Prpers<prn><subj><p1><mf><sg>$ ^be<test><test2><vbser><pres><p1><sg>$ [[t:b:QjZnxQ]]^David<testl><testm><np><cog><sg>$[[t:b:QjZnxQ]]^.<sent>$[]
```

May close #92 