### PR TITLE
Empty blanks are considered blanks again

### DIFF
--- a/apertium/interchunk.cc
+++ b/apertium/interchunk.cc
@@ -1541,15 +1541,7 @@ Interchunk::applyRule()
       if(int(blank_queue.size()) < last_lword - 1)
       {
         string blank_to_add = string(UtfConverter::toUtf8(*tmpblank[i-1]));
-        
-        if(!blank_to_add.empty())
-        {
-          blank_queue.push(blank_to_add);
-        }
-        else
-        {
-          blank_queue.push(" ");
-        }
+        blank_queue.push(blank_to_add);
       }
     }
 

--- a/apertium/postchunk.cc
+++ b/apertium/postchunk.cc
@@ -1849,15 +1849,7 @@ Postchunk::applyRule()
     if(i != 1)
     {
       string blank_to_add = string(UtfConverter::toUtf8(*tmpblank[i-1]));
-      
-      if(!blank_to_add.empty())
-      {
-        blank_queue.push(blank_to_add);
-      }
-      else
-      {
-        blank_queue.push(" ");
-      }
+      blank_queue.push(blank_to_add);
     }
 
     word[i] = new InterchunkWord(UtfConverter::toUtf8(*tmpword[i-1]));

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -2604,15 +2604,7 @@ Transfer::applyRule()
       if(int(blank_queue.size()) < last_lword - 1)
       {
         string blank_to_add = string(UtfConverter::toUtf8(*tmpblank[i-1]));
-        
-        if(!blank_to_add.empty())
-        {
-          blank_queue.push(blank_to_add);
-        }
-        else
-        {
-          blank_queue.push(" ");
-        }
+        blank_queue.push(blank_to_add);
       }
     }
 


### PR DESCRIPTION
Not considering empty blanks caused a problem in rules where the user wanted the same blank as was in the input (even if it was an empty one), such as the num_noun rule, which could be "two cows", or "2F", etc.

Modified transfer, interchunk, and postchunk.