### PR TITLE
fix off-by-one error in hmm tagger (#111)

### DIFF
--- a/apertium/file_morpho_stream.cc
+++ b/apertium/file_morpho_stream.cc
@@ -219,7 +219,7 @@ FileMorphoStream::lrlmClassify(wstring const &str, int &ivwords)
 	if(str[last_pos+1] == L'+' && last_pos+1 < limit )
 	{
 	  floor = last_pos + 1;
-	  last_pos = floor;
+	  last_pos = floor + 1;
           vwords[ivwords]->set_plus_cut(true);
           if (((int)vwords.size())<=((int)(ivwords+1)))
             vwords.push_back(new TaggerWord(true));


### PR DESCRIPTION
Off-by-one errors being, as we know, one of the 3 most annoying errors along with segfaults.

In the case of a compound where the first segment was known and the second was unknown, this line caused the lexical form of the second part to be recorded as empty.