### PR TITLE
configure.ac: fix bashism

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,7 @@ for version in 23 2b 20 2a 17; do
   version_flag="-std=c++${version}"
   AX_CHECK_COMPILE_FLAG([${version_flag}], [break], [version_flag=none])
 done
-AS_IF([test "$version_flag" == none], [
+AS_IF([test "$version_flag" = none], [
   AC_MSG_ERROR([Could not enable at least C++17 - upgrade your compiler])
 ])
 CXXFLAGS="$CXXFLAGS ${version_flag}"


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors like this aren't spotted. Notably Debian defaults to /bin/sh provided by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Signed-off-by: Sam James <sam@gentoo.org>