### PR TITLE
 Implement <reject-current-rule shifting="N"/>

### DIFF
--- a/apertium/interchunk.cc
+++ b/apertium/interchunk.cc
@@ -472,24 +472,39 @@ Interchunk::interchunk(InputFile& in, UFILE* out)
     {
       if(lastrule != NULL)
       {
-        int words_to_consume = applyRule();
-        if (words_to_consume == -1) {
+        int num_words_to_consume = applyRule();
+
+        //Consume all the words from the input which matched the rule.
+        //This piece of code is executed unless the rule contains a "reject-current-rule" instruction
+        if(num_words_to_consume < 0)
+        {
           banned_rules.clear();
           input_buffer.setPos(last);
-        } else if (words_to_consume == 1) {
+        }
+        else if(num_words_to_consume > 0)
+        {
           banned_rules.clear();
-          if (prev_last >= input_buffer.getSize()) {
+          if(prev_last >= input_buffer.getSize())
+          {
             input_buffer.setPos(0);
-          } else {
+          }
+          else
+          {
             input_buffer.setPos(prev_last+1);
           }
-          while (true) {
-            TransferToken& tt = input_buffer.next();
-            if (tt.getType() == tt_word) {
-              break;
+          int num_consumed_words = 0;
+          while(num_consumed_words < num_words_to_consume)
+          {
+            TransferToken& local_tt = input_buffer.next();
+            if (local_tt.getType() == tt_word)
+            {
+              num_consumed_words++;
             }
           }
-        } else {
+        }
+        else
+        {
+          //Add rule to banned rules
           banned_rules.insert(lastrule_id);
           input_buffer.setPos(prev_last);
           input_buffer.next();
@@ -499,7 +514,8 @@ Interchunk::interchunk(InputFile& in, UFILE* out)
       }
       else
       {
-        if(tmpword.size() != 0) {
+        if(tmpword.size() != 0)
+        {
           u_fprintf(output, "^%S$", tmpword[0]->c_str());
           tmpword.clear();
           input_buffer.setPos(last);

--- a/apertium/interchunk.cc
+++ b/apertium/interchunk.cc
@@ -493,7 +493,7 @@ Interchunk::interchunk(InputFile& in, UFILE* out)
             input_buffer.setPos(prev_last+1);
           }
           int num_consumed_words = 0;
-          while(num_consumed_words < num_words_to_consume)
+          while(num_consumed_words < num_words_to_consume && !input_buffer.isEmpty())
           {
             TransferToken& local_tt = input_buffer.next();
             if (local_tt.getType() == tt_word)

--- a/apertium/interchunk.dtd
+++ b/apertium/interchunk.dtd
@@ -426,13 +426,15 @@ get-case-from -->
 <!-- Concatenates a sequence of values -->
 
 <!ELEMENT reject-current-rule EMPTY>
-<!ATTLIST reject-current-rule shifting (yes|no) #IMPLIED>
+<!ATTLIST reject-current-rule shifting CDATA #REQUIRED>
 <!--
-      This instruction cancels the execution of the rule being processed.
-      If "shifting" is set to "yes" or is not specified, the matching process
-      consumes exactly one word at the input. If "shifting" is set to "no"
-      then marks the rule to not to be considered in the current matching
-      until the input buffer advances at least one single word
+      This instruction cancels the execution of the rule being
+      processed. If "shifting" is set to "yes" or "1", the matching
+      process consumes exactly one word of the input; higher numbers
+      mean we consume that many words of the input. If "shifting" is
+      set to "no", the rule will not be considered in the current
+      matching until the input buffer advances at least one single
+      word.
 -->
 
 <!ELEMENT chunk (%value;)+>

--- a/apertium/postchunk.cc
+++ b/apertium/postchunk.cc
@@ -588,7 +588,7 @@ Postchunk::postchunk(InputFile& in, UFILE* out)
             input_buffer.setPos(prev_last+1);
           }
           int num_consumed_words = 0;
-          while(num_consumed_words < num_words_to_consume)
+          while(num_consumed_words < num_words_to_consume && !input_buffer.isEmpty())
           {
             TransferToken& local_tt = input_buffer.next();
             if (local_tt.getType() == tt_word)

--- a/apertium/postchunk.cc
+++ b/apertium/postchunk.cc
@@ -567,24 +567,39 @@ Postchunk::postchunk(InputFile& in, UFILE* out)
     {
       if(lastrule != NULL)
       {
-        int words_to_consume = applyRule();
-        if (words_to_consume == -1) {
+        int num_words_to_consume = applyRule();
+
+        //Consume all the words from the input which matched the rule.
+        //This piece of code is executed unless the rule contains a "reject-current-rule" instruction
+        if(num_words_to_consume < 0)
+        {
           banned_rules.clear();
           input_buffer.setPos(last);
-        } else if (words_to_consume == 1) {
+        }
+        else if(num_words_to_consume > 0)
+        {
           banned_rules.clear();
-          if (prev_last >= input_buffer.getSize()) {
+          if(prev_last >= input_buffer.getSize())
+          {
             input_buffer.setPos(0);
-          } else {
+          }
+          else
+          {
             input_buffer.setPos(prev_last+1);
           }
-          while (true) {
-            TransferToken& tt = input_buffer.next();
-            if (tt.getType() == tt_word) {
-              break;
+          int num_consumed_words = 0;
+          while(num_consumed_words < num_words_to_consume)
+          {
+            TransferToken& local_tt = input_buffer.next();
+            if (local_tt.getType() == tt_word)
+            {
+              num_consumed_words++;
             }
           }
-        } else {
+        }
+        else
+        {
+          //Add rule to banned rules
           banned_rules.insert(lastrule_id);
           input_buffer.setPos(prev_last);
           input_buffer.next();

--- a/apertium/postchunk.dtd
+++ b/apertium/postchunk.dtd
@@ -415,13 +415,15 @@ get-case-from -->
 <!-- Concatenates a sequence of values -->
 
 <!ELEMENT reject-current-rule EMPTY>
-<!ATTLIST reject-current-rule shifting (yes|no) #IMPLIED>
+<!ATTLIST reject-current-rule shifting CDATA #REQUIRED>
 <!--
-      This instruction cancels the execution of the rule being processed.
-      If "shifting" is set to "yes" or is not specified, the matching process
-      consumes exactly one word at the input. If "shifting" is set to "no"
-      then marks the rule to not to be considered in the current matching
-      until the input buffer advances at least one single word
+      This instruction cancels the execution of the rule being
+      processed. If "shifting" is set to "yes" or "1", the matching
+      process consumes exactly one word of the input; higher numbers
+      mean we consume that many words of the input. If "shifting" is
+      set to "no", the rule will not be considered in the current
+      matching until the input buffer advances at least one single
+      word.
 -->
 
 <!ELEMENT mlu (lu+)>

--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -997,7 +997,7 @@ Transfer::transfer(InputFile& in, UFILE* out)
             input_buffer.setPos(prev_last+1);
           }
           int num_consumed_words = 0;
-          while(num_consumed_words < num_words_to_consume)
+          while(num_consumed_words < num_words_to_consume && !input_buffer.isEmpty())
           {
             TransferToken& local_tt = input_buffer.next();
             if (local_tt.getType() == tt_word)

--- a/apertium/transfer.dtd
+++ b/apertium/transfer.dtd
@@ -456,13 +456,15 @@ get-case-from -->
 <!-- Encloses a word inside an 'out' element. -->
 
 <!ELEMENT reject-current-rule EMPTY>
-<!ATTLIST reject-current-rule shifting (yes|no) #IMPLIED>
+<!ATTLIST reject-current-rule shifting CDATA #REQUIRED>
 <!--
-      This instruction cancels the execution of the rule being processed.
-      If "shifting" is set to "yes" or is not specified, the matching process
-      consumes exactly one word at the input. If "shifting" is set to "no"
-      then marks the rule to not to be considered in the current matching
-      until the input buffer advances at least one single word
+      This instruction cancels the execution of the rule being
+      processed. If "shifting" is set to "yes" or "1", the matching
+      process consumes exactly one word of the input; higher numbers
+      mean we consume that many words of the input. If "shifting" is
+      set to "no", the rule will not be considered in the current
+      matching until the input buffer advances at least one single
+      word.
 -->
 
 <!ELEMENT chunk (tags,(mlu|lu|b|var)+)>

--- a/apertium/transfer_base.cc
+++ b/apertium/transfer_base.cc
@@ -310,8 +310,15 @@ TransferBase::processInstruction(xmlNode* localroot)
 int
 TransferBase::processRejectCurrentRule(xmlNode* localroot)
 {
-  bool shifting = (getattr(localroot, "shifting") == "yes"_u);
-  return shifting ? 1 : 0;
+  UString shifting_value = getattr(localroot, "shifting");
+  if(shifting_value == "yes"_u) {
+    // Be backwards compatible:
+    return 1;
+  }
+  else {
+    // A value of "no" will also give 0 which is what we want:
+    return StringUtils::stoi(shifting_value);
+  }
 }
 
 int


### PR DESCRIPTION
where N is a pattern-item position; this lets us use it for lookahead on rules of more than two pattern-items:

```xml
    <rule comment="transpose word 3 and 4; lookahead on word 5">
      <pattern>
        <pattern-item n="pasvsubj"/>    <!-- den -->
        <pattern-item n="aux"/>         <!-- blir -->
        <pattern-item n="pasv-pp"/>     <!-- driven-->
        <pattern-item n="adv_unbound"/> <!-- i dag -->
        <pattern-item n="prep"/>        <!-- Ensure following preposition -->
      </pattern>
      <action>
        <out>
          <chunk><clip pos="1" part="whole"/></chunk> <b/> <!-- den -->
          <chunk><clip pos="2" part="whole"/></chunk> <b/> <!-- blir -->
          <chunk><clip pos="4" part="whole"/></chunk> <b/> <!-- i dag -->
          <chunk><clip pos="3" part="whole"/></chunk> <b/> <!-- driven -->
        </out>
        <reject-current-rule shifting="4"/>
      </action>
    </rule>
```

(we typically want the last preposition to be the start of noun phrase rules)

Fixes #194


So far 436233 nob-nno corpus lines have processed without any diffs (when not using this feature, just checking for backwards-compatibility), so doesn't seem to introduce any regressions. But @hectoralos do you have a test set I should try?