### PR TITLE
Skip customXml in docx

### DIFF
--- a/apertium/apertium-header.sh
+++ b/apertium/apertium-header.sh
@@ -290,7 +290,7 @@ translate_docx () {
   done;
 
   find "$INPUT_TMPDIR" -name "*.xml" |\
-  grep -E -v -i '(settings|theme|styles|font|rels|docProps|Content_Types)' |\
+  grep -E -v -i '(settings|theme|styles|font|rels|docProps|Content_Types|customXml)' |\
   apertium-adapt-docx -n |\
   apertium-deswxml "${FORMAT_OPTIONS[@]}" |\
   if [[ -z "$TRANSLATION_MEMORY_FILE" ]];


### PR DESCRIPTION
Users can include arbitrary XML here, not visible in the document, Some use it to add tags like "this document should be archived"; stuff that should probably not be translated. Sometimes apertium even gives invalid xml here, which leads to scary warnings on opening the docx.