### PR TITLE
issue#184 fix for apertium/pretransfer.cc

### DIFF
--- a/apertium/pretransfer.cc
+++ b/apertium/pretransfer.cc
@@ -160,6 +160,18 @@ void processStream(InputFile& input, UFILE* output, bool null_flush, bool surfac
     {
       break;
     }
+    
+    if (mychar == '\\') {
+      int nextchar = input.get();
+      if (nextchar == '/') {
+        u_fputc(nextchar, output); // Output the escaped forward slash
+      } else {
+        u_fputc(mychar, output); // Output the backslash if not followed by a slash
+        u_fputc(nextchar, output);
+      }
+      continue;
+    }
+
     switch(mychar)
     {
       case '[':
@@ -190,11 +202,6 @@ void processStream(InputFile& input, UFILE* output, bool null_flush, bool surfac
           readAndWriteUntil(input, output, ']');
           u_fputc(']', output);
         }
-        break;
-
-      case '\\':
-        u_fputc(mychar, output);
-        u_fputc(input.get(), output);
         break;
 
       case '^':


### PR DESCRIPTION
void processStream(InputFile& input, UFILE* output, bool null_flush, bool surface_forms, bool compound_sep)
{
  while(true)
  {
    int mychar = input.get();
    if(input.eof())
    {
      break;
    }
    
    if (mychar == '\\') {
      int nextchar = input.get();
      if (nextchar == '/') {
        u_fputc(nextchar, output); // Output the escaped forward slash
      } else {
        u_fputc(mychar, output); // Output the backslash if not followed by a slash
        u_fputc(nextchar, output);
      }
      continue;
    }

    switch(mychar)
    {
      case '[':
        u_fputc('[', output);
        mychar = input.get();

        if(mychar == '[')
        {
          u_fputc('[', output);
          UString wblank = storeAndWriteWblank(input, output);
          mychar = input.get();

          if(mychar == '^')
          {
            u_fputc(mychar, output);
            procWord(input, output, surface_forms, compound_sep, wblank);
            u_fputc('$', output);
          }
          else
          {
            std::cerr << "ERROR: Wordbound blank isn't immediately followed by the Lexical Unit." << std::endl;
            exit(EXIT_FAILURE);
          }
        }
        else
        {
          input.unget(mychar);
          readAndWriteUntil(input, output, ']');
          u_fputc(']', output);
        }
        break;

      case '^':
        u_fputc(mychar, output);
        procWord(input, output, surface_forms, compound_sep);
        u_fputc('$', output);
        break;

      case '\0':
        u_fputc(mychar, output);

        if(null_flush)
        {
          u_fflush(output);
        }
        break;

      default:
        u_fputc(mychar, output);
        break;
    }
  }
}
