### PR TITLE
Break on EOF/NUL inside superblanks

### DIFF
--- a/apertium/transfer.cc
+++ b/apertium/transfer.cc
@@ -861,6 +861,15 @@ Transfer::readToken(InputFile& in)
           content += ']';
           break;
         }
+        else if(val2 == U_EOF)
+        {
+          break;                // should not happen
+        }
+        else if(val2 == '\0')
+        {
+          in.unget(val2);
+          break;
+        }
         else
         {
           content += val2;


### PR DESCRIPTION
@mr-martian  does transfer currently expect \0 to be outside superblanks?
(should we flush on \0 in there?)