### PR TITLE
Allow comments in TSX tagset

### DIFF
--- a/apertium/tsx_reader.cc
+++ b/apertium/tsx_reader.cc
@@ -273,7 +273,7 @@ TSXReader::procTagset()
   while(type == XML_READER_TYPE_END_ELEMENT || name != "tagset"_u)
   {
     step();
-    if(name != "#text"_u && name != "tagger"_u && name != "tagset"_u)
+    if(name != "#text"_u && name != "tagger"_u && name != "tagset"_u && name != "#comment"_u)
     {
       unexpectedTag();
     }


### PR DESCRIPTION
If an XML comment is placed before TSX tagsets, like https://github.com/apertium/apertium-eng/blob/main/apertium-eng.eng.tsx, the TSX parser throws an error. This PR makes the parser ignore the comment.