### PR TITLE
Add autoseq_trace debug mode #219

### DIFF
--- a/apertium/gen_modes.cc
+++ b/apertium/gen_modes.cc
@@ -160,6 +160,8 @@ void set_debug_suffixes(pipeline& prog)
         cmd.debug_suffix.push_back("-pgen");
       } else {
         cmd.debug_suffix.push_back("-autoseq");
+        cmd.debug_suffix.push_back("-autoseq_trace");
+
       }
     } else if (starts_with(c, "rtx-proc")) {
       cmd.debug_suffix.push_back("-transfer");

--- a/apertium/gen_modes.cc
+++ b/apertium/gen_modes.cc
@@ -183,6 +183,15 @@ void set_trace_opt(pipeline& mode)
     return;
   }
   auto& cmd = mode.steps.back().command;
+ 
+// If trace mode, switch autoseq binary to trace version
+if (cmd.find("autoseq") != std::string::npos &&
+    cmd.find("trace") != std::string::npos) {
+
+    size_t pos = cmd.find("autoseq");
+    cmd.replace(pos, std::string("autoseq").length(), "autoseq-trace");
+}
+}
   if (starts_with(cmd, "cg-proc") || starts_with(cmd, "lrx-proc") ||
      starts_with(cmd, "apertium-transfer") ||
      starts_with(cmd, "apertium-interchunk") ||

--- a/apertium/gen_modes.cc
+++ b/apertium/gen_modes.cc
@@ -176,26 +176,26 @@ void set_debug_suffixes(pipeline& prog)
     }
   }
 }
-
 void set_trace_opt(pipeline& mode)
 {
   if (mode.steps.empty()) {
     return;
   }
+
   auto& cmd = mode.steps.back().command;
-  if (mode.name.find("trace") != std::string::npos &&
-    cmd.find("autoseq") != std::string::npos) {
 
+  // If trace mode, ensure autoseq uses the trace-enabled binary
+  if (mode.name.find("trace") != std::string::npos) {
     size_t pos = cmd.find("autoseq");
-    cmd.replace(pos, std::string("autoseq").length(), "autoseq-trace");
-}
-
-}
+    if (pos != std::string::npos) {
+      cmd.replace(pos, std::string("autoseq").length(), "autoseq-trace");
+    }
+  }
 
   if (starts_with(cmd, "cg-proc") || starts_with(cmd, "lrx-proc") ||
-     starts_with(cmd, "apertium-transfer") ||
-     starts_with(cmd, "apertium-interchunk") ||
-     starts_with(cmd, "apertium-postchunk")) {
+      starts_with(cmd, "apertium-transfer") ||
+      starts_with(cmd, "apertium-interchunk") ||
+      starts_with(cmd, "apertium-postchunk")) {
     cmd += " -t";
   } else if (starts_with(cmd, "rtx-proc")) {
     cmd += " -r";

--- a/apertium/gen_modes.cc
+++ b/apertium/gen_modes.cc
@@ -183,15 +183,15 @@ void set_trace_opt(pipeline& mode)
     return;
   }
   auto& cmd = mode.steps.back().command;
- 
-// If trace mode, switch autoseq binary to trace version
-if (cmd.find("autoseq") != std::string::npos &&
-    cmd.find("trace") != std::string::npos) {
+  if (mode.name.find("trace") != std::string::npos &&
+    cmd.find("autoseq") != std::string::npos) {
 
     size_t pos = cmd.find("autoseq");
     cmd.replace(pos, std::string("autoseq").length(), "autoseq-trace");
 }
+
 }
+
   if (starts_with(cmd, "cg-proc") || starts_with(cmd, "lrx-proc") ||
      starts_with(cmd, "apertium-transfer") ||
      starts_with(cmd, "apertium-interchunk") ||


### PR DESCRIPTION
### Summary
This PR adds automatic generation of the `autoseq_trace` debug mode in `gen_modes.cc`, removing the need for manual configuration.

### What was changed
- Added `autoseq_trace` as a debug suffix alongside `autoseq`
- Ensures `apertium-gen-modes` creates the trace mode automatically

### Why this is needed
Previously, `autoseq_trace` had to be manually created. This change aligns it with existing automatic debug mode generation and improves developer workflow.

### Related Issue
Fixes #219